### PR TITLE
Add "web" feature for wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,22 @@ exclude = [
     "screenshots/*",
 ]
 
+[features]
+
+default = [
+    "bevy/bevy_wgpu",
+    "bevy/bevy_winit",
+    "bevy/png",
+    "bevy/render",
+]
+
+web = [
+    "bevy/bevy_winit",
+    "bevy/render",
+]
+
 [dependencies]
-bevy = "0.5"
+bevy = { version = "0.5", default-features = false }
 log = "0.4"
 dyn-clone = "1.0"
 

--- a/src/render/pipeline.rs
+++ b/src/render/pipeline.rs
@@ -1,4 +1,16 @@
-use bevy::{prelude::*, reflect::TypeUuid, render::{pipeline::{BlendFactor, BlendOperation, BlendState, ColorTargetState, ColorWrite, CompareFunction, CullMode, DepthBiasState, DepthStencilState, FrontFace, PipelineDescriptor, PolygonMode, PrimitiveState, PrimitiveTopology, StencilFaceState, StencilState}, shader::{ShaderStage, ShaderStages}, texture::TextureFormat}};
+use bevy::{
+    prelude::*,
+    reflect::TypeUuid,
+    render::{
+        pipeline::{
+            BlendFactor, BlendOperation, BlendState, ColorTargetState, ColorWrite, CompareFunction,
+            CullMode, DepthBiasState, DepthStencilState, FrontFace, PipelineDescriptor,
+            PolygonMode, PrimitiveState, PrimitiveTopology, StencilFaceState, StencilState,
+        },
+        shader::{ShaderStage, ShaderStages},
+        texture::TextureFormat,
+    },
+};
 
 pub const TILE_MAP_PIPELINE_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 4129645945969645246);
@@ -46,11 +58,19 @@ pub fn build_tile_map_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescript
         ..PipelineDescriptor::new(ShaderStages {
             vertex: shaders.add(Shader::from_glsl(
                 ShaderStage::Vertex,
-                include_str!("tilemap.vert"),
+                if cfg!(feature = "web") {
+                    include_str!("tilemap.es.vert")
+                } else {
+                    include_str!("tilemap.vert")
+                },
             )),
             fragment: Some(shaders.add(Shader::from_glsl(
                 ShaderStage::Fragment,
-                include_str!("tilemap.frag"),
+                if cfg!(feature = "web") {
+                    include_str!("tilemap.es.frag")
+                } else {
+                    include_str!("tilemap.frag")
+                },
             ))),
         })
     }

--- a/src/render/tilemap.es.frag
+++ b/src/render/tilemap.es.frag
@@ -1,0 +1,25 @@
+#version 300 es
+
+precision highp float;
+
+in vec2 v_Uv;
+
+out vec4 o_Target;
+
+layout(std140) uniform ColorMaterial_color { // set = 1, binding = 1
+    vec4 Color;
+};
+
+# ifdef COLORMATERIAL_TEXTURE
+uniform sampler2D ColorMaterial_texture;  // set = 1, binding = 1
+# endif
+
+void main() {
+    vec4 color = Color;
+# ifdef COLORMATERIAL_TEXTURE
+    color *= texture(
+        ColorMaterial_texture,
+        v_Uv);
+# endif
+    o_Target = color;
+}

--- a/src/render/tilemap.es.vert
+++ b/src/render/tilemap.es.vert
@@ -1,0 +1,26 @@
+#version 300 es
+
+precision highp float;
+
+in vec3 Vertex_Position;
+in vec3 Vertex_Normal;
+in vec2 Vertex_Uv;
+
+out vec2 v_Uv;
+
+layout(std140) uniform CameraViewProj { // set = 0, binding = 0
+    mat4 ViewProj;
+};
+
+layout(std140) uniform Transform { // set = 2, binding = 0
+    mat4 Model;
+};
+
+void main() {
+    vec2 uv = Vertex_Uv;
+
+    v_Uv = uv;
+    v_Uv += 1e-5;
+    vec3 position = Vertex_Position;
+    gl_Position = ViewProj * Model * vec4(position, 1.0);
+}


### PR DESCRIPTION
There are two main things going on here

- swapping in a separate set of opengles compatible shaders
- using default-features=false for bevy (`bevy_wgpu` and perhaps others won't compile for wasm32)

I think that it should be possible to clean this up using cargo's `resolver="2"` new feature resolver. I think It **should** be possible to:

- use e.g. `[target.'cfg(target_arch = "wasm32")'.dependencies]` instead of adding a web feature
- make `bevy_wgpu`, `bevy_winit`, and `bevy_png` dev-dependencies

But I couldn't manage to make it work, and ran out of time.

Also, I only tested with one of the examples slapped into [bevy_webgl2_app_template](https://github.com/mrk-its/bevy_webgl2_app_template)

Please feel free to close / edit / whatever.