### PR TITLE
Isometric tilemap height correction

### DIFF
--- a/examples/iso.rs
+++ b/examples/iso.rs
@@ -10,35 +10,51 @@ fn startup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
+    // Create the camera setup
     commands.spawn_bundle(OrthographicCameraBundle::new_2d());
 
+    // Load textures
     let texture_handle = asset_server.load("iso.png");
+    
+    // Apply textures to materials
     let material_handle = materials.add(ColorMaterial::texture(texture_handle));
 
+    // Set a ratio for texture size. Higher means chunkier textures
+
+
     let mut map_settings = MapSettings::new(
-        UVec2::new(4, 4),
-        UVec2::new(32, 32),
-        Vec2::new(64.0, 32.0),
-        Vec2::new(640.0, 1024.0),
-        0,
+        UVec2::new(4, 4), // Map Size
+        UVec2::new(32, 32), // Chunk Size
+        Vec2::new(64.0, 64.0), //Tile Size
+        Vec2::new(640.0, 1024.0), // Texture Size
+        0, // Layer ID
     );
+
+    // We want an isometric map, so We'll set the mesh_type to the relevant type
     map_settings.mesh_type = TilemapMeshType::Isometric;
 
-    // Layer 0
+    // Get a map for Layer 0
     let mut map = Map::new(map_settings.clone());
-    let map_entity = commands.spawn().id();
+    
+    // Get an entity ID to be able to refer to the map later on
+    let map_entity_id = commands.spawn().id();
+    
+    // Iterate through all tiles and populate all of these with the same texture
+    // The fifth argument is a function which is iterated though. 
     map.build_iter(
         &mut commands,
         &mut meshes,
         material_handle.clone(),
-        map_entity,
+        map_entity_id,
         |_| Tile {
             texture_index: 10,
             ..Default::default()
         },
     );
 
-    commands.entity(map_entity).insert_bundle(MapBundle {
+    // Save the map and add the Bevy bundle
+    // containing Map, Transform and GlobalTransform components
+    commands.entity(map_entity_id).insert_bundle(MapBundle {
         map,
         transform: Transform::from_xyz(0.0, 0.0, 0.0),
         ..Default::default()
@@ -67,7 +83,7 @@ fn startup(
                 &mut commands,
                 position,
                 Tile {
-                    texture_index: 10 + z + 1,
+                    texture_index: 70 + z + 1,
                     ..Default::default()
                 },
                 true,

--- a/examples/iso.rs
+++ b/examples/iso.rs
@@ -19,7 +19,7 @@ fn startup(
     // Apply textures to materials
     let material_handle = materials.add(ColorMaterial::texture(texture_handle));
 
-
+    // map_size * chunk_size is the maximum canvas we can use when generating tiles
     let map_size_x:u32 = 4;
     let map_size_y:u32 = 4;
 
@@ -28,10 +28,6 @@ fn startup(
 
     let tile_size_x:f32 = 64.0;
     let tile_size_y:f32 = 64.0;
-
-
-
-
 
     let mut map_settings = MapSettings::new(
         UVec2::new(map_size_x.clone(), map_size_y.clone()), // Map Size
@@ -90,58 +86,24 @@ fn startup(
         let mut random = thread_rng();
 
         for _ in 0..1000 {
-            // For now we do not want to spawn any hills next to the edge.
+            // For now we do not want to spawn any grass next to the edge.
             // If we do, we need to add a check so we do not try to address out of bounds tiles
             let max_x = (chunk_size_x.clone() * map_size_x.clone()) - 10;
             let max_y = (chunk_size_y.clone() * map_size_y.clone()) - 10;
 
             let position = UVec2::new(random.gen_range(10..max_x), random.gen_range(10..max_y));
 
+
             let _ = map.add_tile(
                 &mut commands,
                 position,
                 Tile {
-                    texture_index: 42,
+                    texture_index: random.gen_range(118..121),
                     ..Default::default()
                 },
                 true,
             );
 
-            let mut new_pos = position.clone();
-            new_pos[1] -= 1;
-            let _ = map.add_tile(
-                &mut commands,
-                new_pos,
-                Tile {
-                    texture_index: 41,
-                    ..Default::default()
-                },
-                true,
-            );
-
-            let mut new_pos = position.clone();
-            new_pos[0] += 1;
-            let _ = map.add_tile(
-                &mut commands,
-                new_pos,
-                Tile {
-                    texture_index: 43,
-                    ..Default::default()
-                },
-                true,
-            );
-
-            let mut new_pos = position.clone();
-            new_pos[0] -= 1;
-            let _ = map.add_tile(
-                &mut commands,
-                new_pos,
-                Tile {
-                    texture_index: 40,
-                    ..Default::default()
-                },
-                true,
-            );
 
         }
         commands.entity(map_entity).insert_bundle(MapBundle {

--- a/src/render/iso-tilemap.vert
+++ b/src/render/iso-tilemap.vert
@@ -22,7 +22,7 @@ layout(set = 2, binding = 1) uniform TilemapData {
 
 vec2 project_iso(vec2 pos, float tile_width, float tile_height) {
     float x = (pos.x - pos.y) * tile_width / 2.0;
-    float y = (pos.x + pos.y) * tile_height / 2.0;
+    float y = (pos.x + pos.y) * tile_height / 4.0;
     return vec2(x, -y);
 }
 


### PR DESCRIPTION
I've made some changes to the isometric rendering to allow for tiles that are not flat to be rendered correctly. In the example I've added some random foliage to show the effect. Still need to figure out the tilemap coordination system, so I was not able to create nice hill/mountain ranges with the correct tiles connecting to each other.

I'm still very new to rust so it is very likely that my approach is not the best.