### PR TITLE
Fix panic on attempting to fetch out of bound tiles.

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -127,7 +127,10 @@ impl Layer {
     }
 
     pub fn get_chunk(&self, chunk_pos: ChunkPos) -> Option<Entity> {
-        *self.chunks.get(morton_index(chunk_pos))?
+        match self.chunks.get(morton_index(chunk_pos)) {
+            Some(Some(chunk)) => Some(*chunk),
+            _ => None,
+        }
     }
 
     /// Gets the map's size in tiles just for convenience.

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -127,7 +127,7 @@ impl Layer {
     }
 
     pub fn get_chunk(&self, chunk_pos: ChunkPos) -> Option<Entity> {
-        self.chunks[morton_index(chunk_pos)]
+        *self.chunks.get(morton_index(chunk_pos))?
     }
 
     /// Gets the map's size in tiles just for convenience.


### PR DESCRIPTION
Fixes #48 

The * and ? were to avoid having a nested option, and to change the least amount of code possible.
I've only tested it on get_tile_entity, but it seems to work.