### PR TITLE
Adds simple readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # `bevy_ecs_tilemap`
+
+[![Crates.io](https://img.shields.io/crates/v/bevy_ecs_tilemap)](https://crates.io/crates/bevy_ecs_tilemap)
+[![docs](https://docs.rs/bevy_ecs_tilemap/badge.svg)](https://docs.rs/bevy_ecs_tilemap/)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/StarArawn/bevy_ecs_tilemap/blob/main/LICENSE)
+[![Crates.io](https://img.shields.io/crates/d/bevy_ecs_tilemap)](https://crates.io/crates/bevy_ecs_tilemap)
+
 A tilemap rendering plugin for [`bevy`](https://bevyengine.org/). It is more ECS friendly as it makes tiles entities.
 
 ## Features


### PR DESCRIPTION
Adds some of those nifty badges like quite a few other bevy crates use to the readme.

Provides a bit easier of access to the Crates.io page and docs.rs for the plugin.