### PR TITLE
Fix spacing in hex grid UVs

### DIFF
--- a/src/render/columnhex-tilemap.vert
+++ b/src/render/columnhex-tilemap.vert
@@ -49,8 +49,8 @@ void main() {
     
     int columns = int(floor(texture_size.x / tile_size.x));
 
-    float sprite_sheet_x = floor(mod(float(texture_index), float(columns)) * (tile_size.x + spacing.x) - spacing.x);
-    float sprite_sheet_y = floor((texture_index / columns)) * (tile_size.y + spacing.y) - spacing.y;
+    float sprite_sheet_x = floor(mod(float(texture_index), float(columns)) * (tile_size.x + spacing.x + spacing.x) + spacing.x);
+    float sprite_sheet_y = floor((texture_index / columns)) * (tile_size.y + spacing.y + spacing.y) + spacing.y;
 
     float start_u = sprite_sheet_x / texture_size.x;
     float end_u = (sprite_sheet_x + tile_size.x) / texture_size.x;

--- a/src/render/rowhex-tilemap.vert
+++ b/src/render/rowhex-tilemap.vert
@@ -49,8 +49,8 @@ void main() {
     
     int columns = int(floor(texture_size.x / tile_size.x));
 
-    float sprite_sheet_x = floor(mod(float(texture_index), float(columns)) * (tile_size.x + spacing.x) - spacing.x);
-    float sprite_sheet_y = floor((texture_index / columns)) * (tile_size.y + spacing.y) - spacing.y;
+    float sprite_sheet_x = floor(mod(float(texture_index), float(columns)) * (tile_size.x + spacing.x + spacing.x) + spacing.x);
+    float sprite_sheet_y = floor((texture_index / columns)) * (tile_size.y + spacing.y + spacing.y) + spacing.y;
 
     float start_u = sprite_sheet_x / texture_size.x;
     float end_u = (sprite_sheet_x + tile_size.x) / texture_size.x;


### PR DESCRIPTION
Change the spacing math to assume that the tile is centered in its "sprite sheet slot". That is, there is equal padding on both sides.

For example, if `spacing.x` is 8, that's 8 pixels on the left + 8 pixels on the right, resulting in a total of 16 pixels increase on top of `tile_size.x`.