### PR TITLE
fix sprite index calculation (columns) in hex shader

### DIFF
--- a/src/render/columnhex-tilemap.vert
+++ b/src/render/columnhex-tilemap.vert
@@ -47,10 +47,12 @@ void main() {
 
     int texture_index = int(current_animation_frame);
     
-    int columns = int(floor(texture_size.x / tile_size.x));
+    vec2 slot_size = tile_size + spacing * 2.0;
 
-    float sprite_sheet_x = floor(mod(float(texture_index), float(columns)) * (tile_size.x + spacing.x + spacing.x) + spacing.x);
-    float sprite_sheet_y = floor((texture_index / columns)) * (tile_size.y + spacing.y + spacing.y) + spacing.y;
+    int columns = int(floor(texture_size.x / slot_size.x));
+
+    float sprite_sheet_x = floor(mod(float(texture_index), float(columns)) * slot_size.x + spacing.x);
+    float sprite_sheet_y = floor((texture_index / columns)) * slot_size.y + spacing.y;
 
     float start_u = sprite_sheet_x / texture_size.x;
     float end_u = (sprite_sheet_x + tile_size.x) / texture_size.x;

--- a/src/render/rowhex-tilemap.vert
+++ b/src/render/rowhex-tilemap.vert
@@ -46,11 +46,13 @@ void main() {
     current_animation_frame = clamp(current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
 
     int texture_index = int(current_animation_frame);
-    
-    int columns = int(floor(texture_size.x / tile_size.x));
 
-    float sprite_sheet_x = floor(mod(float(texture_index), float(columns)) * (tile_size.x + spacing.x + spacing.x) + spacing.x);
-    float sprite_sheet_y = floor((texture_index / columns)) * (tile_size.y + spacing.y + spacing.y) + spacing.y;
+    vec2 slot_size = tile_size + spacing * 2.0;
+    
+    int columns = int(floor(texture_size.x / slot_size.x));
+
+    float sprite_sheet_x = floor(mod(float(texture_index), float(columns)) * slot_size.x + spacing.x);
+    float sprite_sheet_y = floor((texture_index / columns)) * slot_size.y + spacing.y;
 
     float start_u = sprite_sheet_x / texture_size.x;
     float end_u = (sprite_sheet_x + tile_size.x) / texture_size.x;


### PR DESCRIPTION
Yesterday, #68 fixed the rendering of sprites to take spacing into account. However, the handling of the sprite index was still wrong. The number of columns was still calculated without the spacing, so on a large spritesheet, the math behaved as if there are more columns than there really are. This is fixed now.