### PR TITLE
#14 LayerSettings::new_with_map_type

### DIFF
--- a/examples/hex_column.rs
+++ b/examples/hex_column.rs
@@ -19,13 +19,13 @@ fn startup(
     let map_entity = commands.spawn().id();
     let mut map = Map::new(0u16, map_entity);
 
-    let mut map_settings = LayerSettings::new(
+    let map_settings = LayerSettings::new_with_map_type(
         UVec2::new(2, 2),
         UVec2::new(64, 64),
         Vec2::new(17.0, 15.0),
         Vec2::new(102.0, 15.0),
+        TilemapMeshType::Hexagon(HexType::Column)
     );
-    map_settings.mesh_type = TilemapMeshType::Hexagon(HexType::Column);
 
     let (mut layer_builder, layer_entity) =
         LayerBuilder::<TileBundle>::new(&mut commands, map_settings.clone(), 0u16, 0u16, None);

--- a/examples/hex_row.rs
+++ b/examples/hex_row.rs
@@ -19,13 +19,13 @@ fn startup(
     let map_entity = commands.spawn().id();
     let mut map = Map::new(0u16, map_entity);
 
-    let mut map_settings = LayerSettings::new(
+    let map_settings = LayerSettings::new_with_map_type(
         UVec2::new(2, 2),
         UVec2::new(64, 64),
         Vec2::new(15.0, 17.0),
         Vec2::new(105.0, 17.0),
+        TilemapMeshType::Hexagon(HexType::Row)
     );
-    map_settings.mesh_type = TilemapMeshType::Hexagon(HexType::Row);
 
     let (mut layer_builder, layer_entity) =
         LayerBuilder::<TileBundle>::new(&mut commands, map_settings.clone(), 0u16, 0u16, None);
@@ -113,7 +113,7 @@ fn main() {
         .insert_resource(WindowDescriptor {
             width: 1270.0,
             height: 720.0,
-            title: String::from("Hex Map Column Example"),
+            title: String::from("Hex Map Row Example"),
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/iso_diamond.rs
+++ b/examples/iso_diamond.rs
@@ -18,13 +18,13 @@ fn startup(
     let map_entity = commands.spawn().id();
     let mut map = Map::new(0u16, map_entity);
 
-    let mut map_settings = LayerSettings::new(
+    let map_settings = LayerSettings::new_with_map_type(
         UVec2::new(2, 2),
         UVec2::new(32, 32),
         Vec2::new(64.0, 32.0),
         Vec2::new(384.0, 32.0),
+        TilemapMeshType::Isometric(IsoType::Diamond)
     );
-    map_settings.mesh_type = TilemapMeshType::Isometric(IsoType::Diamond);
 
     // Layer 0
     let (mut layer_0, layer_0_entity) =

--- a/examples/iso_staggered.rs
+++ b/examples/iso_staggered.rs
@@ -18,13 +18,13 @@ fn startup(
     let map_entity = commands.spawn().id();
     let mut map = Map::new(0u16, map_entity);
 
-    let mut map_settings = LayerSettings::new(
+    let map_settings = LayerSettings::new_with_map_type(
         UVec2::new(2, 2),
         UVec2::new(16, 32),
         Vec2::new(64.0, 32.0),
         Vec2::new(384.0, 32.0),
+        TilemapMeshType::Isometric(IsoType::Staggered)
     );
-    map_settings.mesh_type = TilemapMeshType::Isometric(IsoType::Staggered);
 
     // Layer 0
     let (mut layer_0, layer_0_entity) =
@@ -121,7 +121,7 @@ fn main() {
         .insert_resource(WindowDescriptor {
             width: 1270.0,
             height: 720.0,
-            title: String::from("Iso diamond Map"),
+            title: String::from("Iso staggered Map"),
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -60,6 +60,27 @@ impl LayerSettings {
         }
     }
 
+    pub fn new_with_map_type(
+        map_size: UVec2,
+        chunk_size: UVec2,
+        tile_size: Vec2,
+        texture_size: Vec2,
+        mesh_type: TilemapMeshType,
+    ) -> Self {
+        Self {
+            map_size,
+            chunk_size,
+            tile_size,
+            texture_size,
+            layer_id: 0,
+            map_id: 0,
+            cull: true,
+            mesh_type,
+            tile_spacing: Vec2::ZERO,
+            mesher: ChunkMesher,
+        }
+    }
+
     pub fn set_layer_id<L: Into<u16>>(&mut self, id: L) {
         self.layer_id = id.into();
     }


### PR DESCRIPTION
Implementation for #14 , should this be named `new_with_mesh_type` or is `new_with_map_type` better?

- Adjusted hex and iso examples to use the new function.
- Corrected window titles for the iso_staggered and hex_row examples.