### PR TITLE
Add traits for map and layer IDs

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,5 +1,6 @@
 use crate::{
     chunk::Chunk,
+    map::MapId,
     morton_index,
     prelude::{ChunkMesher, Tile},
     round_to_power_of_two,
@@ -7,6 +8,7 @@ use crate::{
     ChunkPos, ChunkSize, MapSize, TextureSize, TilePos, TileSize, TilemapMeshType,
 };
 use bevy::prelude::*;
+use std::hash::Hash;
 
 /// A bevy bundle which contains: Map, Transform, and GlobalTransform components.
 #[derive(Bundle, Default)]
@@ -65,11 +67,11 @@ impl LayerSettings {
         }
     }
 
-    pub fn set_layer_id<L: Into<u16>>(&mut self, id: L) {
+    pub fn set_layer_id(&mut self, id: impl LayerId) {
         self.layer_id = id.into();
     }
 
-    pub fn set_map_id<M: Into<u16>>(&mut self, id: M) {
+    pub fn set_map_id(&mut self, id: impl MapId) {
         self.map_id = id.into();
     }
 
@@ -149,3 +151,11 @@ pub(crate) fn update_chunk_hashmap_for_added_tiles(
         }
     }
 }
+
+/// A type that can be used to identify which layer a tile is on.
+///
+/// These are ultimately converted to u16; if you're using more than one type with this trait in your game,
+/// ensure that their u16 conversions do not unintentionally overlap.
+pub trait LayerId: Clone + Copy + PartialEq + Eq + Hash + Into<u16> {}
+
+impl LayerId for u16 {}

--- a/src/layer_builder.rs
+++ b/src/layer_builder.rs
@@ -200,8 +200,12 @@ where
         Err(MapTileError::OutOfBounds)
     }
 
-    /// Returns an existing tile entity or spawns a new one. 
-    pub fn get_tile_entity(&mut self, commands: &mut Commands, tile_pos: UVec2) -> Result<Entity, MapTileError> {
+    /// Returns an existing tile entity or spawns a new one.
+    pub fn get_tile_entity(
+        &mut self,
+        commands: &mut Commands,
+        tile_pos: TilePos,
+    ) -> Result<Entity, MapTileError> {
         let morton_tile_index = morton_index(tile_pos);
         if morton_tile_index < self.tiles.capacity() {
             let tile_entity = if self.tiles[morton_tile_index].0.is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,9 +178,9 @@ fn morton_pos(index: usize) -> UVec2 {
 /// use bevy_ecs_tilemap::prelude::*; to import commonly used components, data structures, bundles, and plugins.
 pub mod prelude {
     pub use crate::chunk::{Chunk, ChunkSettings};
-    pub use crate::layer::{Layer, LayerBundle, LayerSettings, MapTileError};
+    pub use crate::layer::{Layer, LayerBundle, LayerId, LayerSettings, MapTileError};
     pub use crate::layer_builder::LayerBuilder;
-    pub use crate::map::Map;
+    pub use crate::map::{Map, MapId};
     pub use crate::map_query::MapQuery;
     pub(crate) use crate::mesher::ChunkMesher;
     pub use crate::tile::{GPUAnimated, Tile, TileBundle, TileBundleTrait, TileParent};

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,4 +1,6 @@
+use crate::layer::LayerId;
 use bevy::prelude::*;
+use std::hash::Hash;
 use std::{collections::HashMap, vec::IntoIter};
 
 /// A simple component used to keep track of layer entities.
@@ -21,7 +23,7 @@ impl Default for Map {
 
 impl Map {
     /// Creates a new map component
-    pub fn new<M: Into<u16>>(id: M, map_entity: Entity) -> Self {
+    pub fn new(id: impl MapId, map_entity: Entity) -> Self {
         Self {
             map_entity,
             id: id.into(),
@@ -30,10 +32,10 @@ impl Map {
     }
 
     /// Creates a new layer.
-    pub fn add_layer<L: Into<u16>>(
+    pub fn add_layer(
         &mut self,
         commands: &mut Commands,
-        layer_id: L,
+        layer_id: impl LayerId,
         layer_entity: Entity,
     ) {
         commands
@@ -43,10 +45,10 @@ impl Map {
     }
 
     /// Adds multiple layers to the map.
-    pub fn add_layers<L: Into<u16>>(
+    pub fn add_layers(
         &mut self,
         commands: &mut Commands,
-        layers: IntoIter<(L, Entity)>,
+        layers: IntoIter<(impl LayerId, Entity)>,
     ) {
         let layers: Vec<(u16, Entity)> = layers.map(|(id, entity)| (id.into(), entity)).collect();
         let entities: Vec<Entity> = layers.iter().map(|(_, entity)| *entity).collect();
@@ -56,7 +58,7 @@ impl Map {
 
     /// Removes the layer from the map and despawns the layer entity.
     /// Note: Does not despawn the tile entities. Please use MapQuery instead.
-    pub fn remove_layer<L: Into<u16>>(&mut self, commands: &mut Commands, layer_id: L) {
+    pub fn remove_layer(&mut self, commands: &mut Commands, layer_id: impl LayerId) {
         if let Some(layer_entity) = self.layers.remove(&layer_id.into()) {
             commands.entity(layer_entity).despawn_recursive();
         }
@@ -64,7 +66,7 @@ impl Map {
 
     /// Removes the layers from the map and despawns the layer entities.
     /// Note: Does not despawn the tile entities. Please use MapQuery instead.
-    pub fn remove_layers<L: Into<u16>>(&mut self, commands: &mut Commands, layers: IntoIter<L>) {
+    pub fn remove_layers(&mut self, commands: &mut Commands, layers: IntoIter<impl LayerId>) {
         layers.for_each(|id| {
             let id: u16 = id.into();
             self.remove_layer(commands, id);
@@ -72,7 +74,7 @@ impl Map {
     }
 
     /// Retrieves the entity for a given layer id.
-    pub fn get_layer_entity<L: Into<u16>>(&self, layer_id: L) -> Option<&Entity> {
+    pub fn get_layer_entity(&self, layer_id: impl LayerId) -> Option<&Entity> {
         self.layers.get(&layer_id.into())
     }
 
@@ -88,3 +90,11 @@ impl Map {
             .collect()
     }
 }
+
+/// A type that can be used to identify which map a tile is in.
+///
+/// These are ultimately converted to u16; if you're using more than one type with this trait in your game,
+/// ensure that their u16 conversions do not unintentionally overlap.
+pub trait MapId: Clone + Copy + PartialEq + Eq + Hash + Into<u16> {}
+
+impl MapId for u16 {}

--- a/src/map_query.rs
+++ b/src/map_query.rs
@@ -63,13 +63,13 @@ impl<'a> MapQuery<'a> {
     ///   tile.texture_index = 10;
     /// }
     /// ```
-    pub fn set_tile<M: Into<u16> + Copy, L: Into<u16> + Copy>(
+    pub fn set_tile(
         &mut self,
         commands: &mut Commands,
         tile_pos: TilePos,
         tile: Tile,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) -> Result<Entity, MapTileError> {
         let map_id = map_id.into();
         let layer_id = layer_id.into();
@@ -117,10 +117,10 @@ impl<'a> MapQuery<'a> {
         Err(MapTileError::OutOfBounds)
     }
 
-    pub fn get_layer<M: Into<u16>, L: Into<u16>>(
+    pub fn get_layer(
         &self,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) -> Option<(Entity, &Layer)> {
         let map_id = map_id.into();
         let layer_id = layer_id.into();
@@ -141,11 +141,11 @@ impl<'a> MapQuery<'a> {
     }
 
     /// Gets a tile entity for the given position and layer_id returns an error if OOB or the tile doesn't exist.
-    pub fn get_tile_entity<M: Into<u16> + Copy, L: Into<u16> + Copy>(
+    pub fn get_tile_entity(
         &self,
         tile_pos: TilePos,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) -> Result<Entity, MapTileError> {
         let map_id = map_id.into();
         let layer_id = layer_id.into();
@@ -179,10 +179,10 @@ impl<'a> MapQuery<'a> {
     }
 
     /// Despawns the tile entity and removes it from the layer/chunk cache.
-    pub fn despawn_tile<M: Into<u16>, L: Into<u16>>(
+    pub fn despawn_tile(
         &mut self,
         commands: &mut Commands,
-        tile_pos: TilePos,
+        tile_pos: UVec2,
         map_id: M,
         layer_id: L,
     ) -> Result<(), MapTileError> {
@@ -223,11 +223,11 @@ impl<'a> MapQuery<'a> {
 
     /// Despawns all of the tiles in a layer.
     /// Note: Doesn't despawn the layer.
-    pub fn despawn_layer_tiles<M: Into<u16>, L: Into<u16>>(
+    pub fn despawn_layer_tiles(
         &mut self,
         commands: &mut Commands,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) {
         let map_id = map_id.into();
         let layer_id = layer_id.into();
@@ -266,11 +266,11 @@ impl<'a> MapQuery<'a> {
     }
 
     /// Despawns a layer completely including all tiles.
-    pub fn despawn_layer<M: Into<u16>, L: Into<u16>>(
+    pub fn despawn_layer(
         &mut self,
         commands: &mut Commands,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) {
         let map_id = map_id.into();
         let layer_id = layer_id.into();
@@ -298,7 +298,7 @@ impl<'a> MapQuery<'a> {
     }
 
     /// Despawn an entire map including all layers/tiles.
-    pub fn despawn<M: Into<u16>>(&mut self, commands: &mut Commands, map_id: M) {
+    pub fn despawn(&mut self, commands: &mut Commands, map_id: impl MapId) {
         let map_id: u16 = map_id.into();
 
         let layer_ids: Option<Vec<u16>> = if let Some((_, map)) = self
@@ -328,17 +328,91 @@ impl<'a> MapQuery<'a> {
         }
     }
 
-    /// Lets the internal systems know to "remesh" the chunk.
+    /// Retrieves a list of neighbor entities in the following order:
+    /// N, S, W, E, NW, NE, SW, SE.
+    ///
+    /// The returned neighbors are tuples that have an tilemap coordinate and an Option<Entity>.
+    ///
+    /// A value of None will be returned for tiles that don't exist.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// let neighbors = map.get_tile_neighbors(UVec2::new(0, 0));
+    /// assert!(neighbors[1].1.is_none()); // Outside of tile bounds.
+    /// assert!(neighbors[0].1.is_none()); // Entity returned inside bounds.
+    /// ```
+    pub fn get_tile_neighbors<M: Into<u16>, L: Into<u16>>(
+        &self,
+        tile_pos: UVec2,
+        map_id: M,
+        layer_id: L,
+    ) -> [(IVec2, Option<Entity>); 8] {
+        let n = IVec2::new(tile_pos.x as i32, tile_pos.y as i32 + 1);
+        let s = IVec2::new(tile_pos.x as i32, tile_pos.y as i32 - 1);
+        let w = IVec2::new(tile_pos.x as i32 - 1, tile_pos.y as i32);
+        let e = IVec2::new(tile_pos.x as i32 + 1, tile_pos.y as i32);
+        let nw = IVec2::new(tile_pos.x as i32 - 1, tile_pos.y as i32 + 1);
+        let ne = IVec2::new(tile_pos.x as i32 + 1, tile_pos.y as i32 + 1);
+        let sw = IVec2::new(tile_pos.x as i32 - 1, tile_pos.y as i32 - 1);
+        let se = IVec2::new(tile_pos.x as i32 + 1, tile_pos.y as i32 - 1);
+        let layer_id: u16 = layer_id.into();
+        let map_id: u16 = map_id.into();
+        [
+            (n, self.get_tile_i(n, map_id, layer_id)),
+            (s, self.get_tile_i(s, map_id, layer_id)),
+            (w, self.get_tile_i(w, map_id, layer_id)),
+            (e, self.get_tile_i(e, map_id, layer_id)),
+            (nw, self.get_tile_i(nw, map_id, layer_id)),
+            (ne, self.get_tile_i(ne, map_id, layer_id)),
+            (sw, self.get_tile_i(sw, map_id, layer_id)),
+            (se, self.get_tile_i(se, map_id, layer_id)),
+        ]
+    }
+
+    fn get_tile_i(&self, tile_pos: IVec2, map_id: u16, layer_id: u16) -> Option<Entity> {
+        if tile_pos.x < 0 || tile_pos.y < 0 {
+            return None;
+        }
+        let tile_pos = tile_pos.as_u32();
+        if let Some((_, map)) = self
+            .map_query_set
+            .q1()
+            .iter()
+            .find(|(_, map)| map.id == map_id)
+        {
+            if let Some(layer_entity) = map.get_layer_entity(layer_id) {
+                if let Ok((_, layer)) = self.layer_query_set.q1().get(*layer_entity) {
+                    let chunk_pos = UVec2::new(
+                        tile_pos.x / layer.settings.chunk_size.x,
+                        tile_pos.y / layer.settings.chunk_size.y,
+                    );
+                    if let Some(chunk_entity) = layer.get_chunk(chunk_pos) {
+                        if let Ok((_, chunk)) = self.chunk_query_set.q1().get(chunk_entity) {
+                            if let Some(tile) = chunk.get_tile_entity(chunk.to_chunk_pos(tile_pos))
+                            {
+                                return Some(tile);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Let's the internal systems know to "remesh" the chunk.
     pub fn notify_chunk(&mut self, chunk_entity: Entity) {
         if let Ok((_, mut chunk)) = self.chunk_query_set.q0_mut().get_mut(chunk_entity) {
             chunk.needs_remesh = true;
         }
     }
 
-    /// Lets the internal systems know to remesh the chunk for a given tile pos and layer_id.
+    /// Let's the internal systems know to remesh the chunk for a given tile pos and layer_id.
     pub fn notify_chunk_for_tile<M: Into<u16>, L: Into<u16>>(
         &mut self,
-        tile_pos: TilePos,
+        tile_pos: UVec2,
         map_id: M,
         layer_id: L,
     ) {

--- a/src/map_query.rs
+++ b/src/map_query.rs
@@ -182,9 +182,9 @@ impl<'a> MapQuery<'a> {
     pub fn despawn_tile(
         &mut self,
         commands: &mut Commands,
-        tile_pos: UVec2,
-        map_id: M,
-        layer_id: L,
+        tile_pos: TilePos,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) -> Result<(), MapTileError> {
         let map_id = map_id.into();
         let layer_id = layer_id.into();
@@ -328,80 +328,6 @@ impl<'a> MapQuery<'a> {
         }
     }
 
-    /// Retrieves a list of neighbor entities in the following order:
-    /// N, S, W, E, NW, NE, SW, SE.
-    ///
-    /// The returned neighbors are tuples that have an tilemap coordinate and an Option<Entity>.
-    ///
-    /// A value of None will be returned for tiles that don't exist.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// let neighbors = map.get_tile_neighbors(UVec2::new(0, 0));
-    /// assert!(neighbors[1].1.is_none()); // Outside of tile bounds.
-    /// assert!(neighbors[0].1.is_none()); // Entity returned inside bounds.
-    /// ```
-    pub fn get_tile_neighbors<M: Into<u16>, L: Into<u16>>(
-        &self,
-        tile_pos: UVec2,
-        map_id: M,
-        layer_id: L,
-    ) -> [(IVec2, Option<Entity>); 8] {
-        let n = IVec2::new(tile_pos.x as i32, tile_pos.y as i32 + 1);
-        let s = IVec2::new(tile_pos.x as i32, tile_pos.y as i32 - 1);
-        let w = IVec2::new(tile_pos.x as i32 - 1, tile_pos.y as i32);
-        let e = IVec2::new(tile_pos.x as i32 + 1, tile_pos.y as i32);
-        let nw = IVec2::new(tile_pos.x as i32 - 1, tile_pos.y as i32 + 1);
-        let ne = IVec2::new(tile_pos.x as i32 + 1, tile_pos.y as i32 + 1);
-        let sw = IVec2::new(tile_pos.x as i32 - 1, tile_pos.y as i32 - 1);
-        let se = IVec2::new(tile_pos.x as i32 + 1, tile_pos.y as i32 - 1);
-        let layer_id: u16 = layer_id.into();
-        let map_id: u16 = map_id.into();
-        [
-            (n, self.get_tile_i(n, map_id, layer_id)),
-            (s, self.get_tile_i(s, map_id, layer_id)),
-            (w, self.get_tile_i(w, map_id, layer_id)),
-            (e, self.get_tile_i(e, map_id, layer_id)),
-            (nw, self.get_tile_i(nw, map_id, layer_id)),
-            (ne, self.get_tile_i(ne, map_id, layer_id)),
-            (sw, self.get_tile_i(sw, map_id, layer_id)),
-            (se, self.get_tile_i(se, map_id, layer_id)),
-        ]
-    }
-
-    fn get_tile_i(&self, tile_pos: IVec2, map_id: u16, layer_id: u16) -> Option<Entity> {
-        if tile_pos.x < 0 || tile_pos.y < 0 {
-            return None;
-        }
-        let tile_pos = tile_pos.as_u32();
-        if let Some((_, map)) = self
-            .map_query_set
-            .q1()
-            .iter()
-            .find(|(_, map)| map.id == map_id)
-        {
-            if let Some(layer_entity) = map.get_layer_entity(layer_id) {
-                if let Ok((_, layer)) = self.layer_query_set.q1().get(*layer_entity) {
-                    let chunk_pos = UVec2::new(
-                        tile_pos.x / layer.settings.chunk_size.x,
-                        tile_pos.y / layer.settings.chunk_size.y,
-                    );
-                    if let Some(chunk_entity) = layer.get_chunk(chunk_pos) {
-                        if let Ok((_, chunk)) = self.chunk_query_set.q1().get(chunk_entity) {
-                            if let Some(tile) = chunk.get_tile_entity(chunk.to_chunk_pos(tile_pos))
-                            {
-                                return Some(tile);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        None
-    }
-
     /// Let's the internal systems know to "remesh" the chunk.
     pub fn notify_chunk(&mut self, chunk_entity: Entity) {
         if let Ok((_, mut chunk)) = self.chunk_query_set.q0_mut().get_mut(chunk_entity) {
@@ -412,7 +338,7 @@ impl<'a> MapQuery<'a> {
     /// Let's the internal systems know to remesh the chunk for a given tile pos and layer_id.
     pub fn notify_chunk_for_tile<M: Into<u16>, L: Into<u16>>(
         &mut self,
-        tile_pos: UVec2,
+        tile_pos: TilePos,
         map_id: M,
         layer_id: L,
     ) {

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -1,5 +1,6 @@
-use crate::layer::MapTileError;
+use crate::layer::{LayerId, MapTileError};
 use crate::layer_builder::LayerBuilder;
+use crate::map::MapId;
 use crate::map_query::MapQuery;
 use crate::tile::TileBundleTrait;
 use crate::TilePos;
@@ -41,11 +42,11 @@ impl<'a> MapQuery<'a> {
     /// assert!(neighbors[1].1.is_none()); // Outside of tile bounds.
     /// assert!(neighbors[0].1.is_none()); // Entity returned inside bounds.
     /// ```
-    pub fn get_tile_neighbors<M: Into<u16> + Copy, L: Into<u16> + Copy>(
+    pub fn get_tile_neighbors(
         &self,
         tile_pos: TilePos,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) -> Vec<Result<Entity, MapTileError>> {
         let neighboring_tile_pos = get_neighboring_pos(tile_pos);
 


### PR DESCRIPTION
These traits are now used instead of `Into<u16>` in the end-user-facing APIs. This clarifies intent over just a `Into<u16>`, allows engine and downstream uses to perform more logic on map and layer ids (as more trait bounds are used), and prevents users from accidentally swapping a map and layer identifier.

These traits are implemented for `u16` by the library itself to avoid breaking user code unnecessarily. I didn't change the example code to use enums as I felt that was out of scope for this PR.

The other design change you could make on top of this is enforcing / encouraging a unified map / layer ID schema by adding map and layer identifier generic types to `TilemapPlugin`. These would be passed in by users when declaring the plugin, and would help avoid clashes.

I don't think this is terribly likely to occur in practice, but it's worth briefly discussing as it communicates the intended usage a bit more clearly IMO. We could also possibly migrate away from using `u16` internally for this at all by taking this approach.