### PR TITLE
Convert TilePos, MapSize and relatives to use usize

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,5 +1,6 @@
 use crate::{
     chunk::Chunk,
+    map::MapId,
     morton_index,
     prelude::{ChunkMesher, Tile},
     round_to_power_of_two,
@@ -7,6 +8,7 @@ use crate::{
     ChunkPos, ChunkSize, MapSize, TextureSize, TilePos, TileSize, TilemapMeshType,
 };
 use bevy::prelude::*;
+use std::hash::Hash;
 
 /// A bevy bundle which contains: Map, Transform, and GlobalTransform components.
 #[derive(Bundle, Default)]
@@ -65,11 +67,11 @@ impl LayerSettings {
         }
     }
 
-    pub fn set_layer_id<L: Into<u16>>(&mut self, id: L) {
+    pub fn set_layer_id(&mut self, id: impl LayerId) {
         self.layer_id = id.into();
     }
 
-    pub fn set_map_id<M: Into<u16>>(&mut self, id: M) {
+    pub fn set_map_id(&mut self, id: impl MapId) {
         self.map_id = id.into();
     }
 
@@ -149,3 +151,11 @@ pub(crate) fn update_chunk_hashmap_for_added_tiles(
         }
     }
 }
+
+/// A type that can be used to identify which layer a tile is on.
+///
+/// These are ultimately converted to u16; if you're using more than one type with this trait in your game,
+/// ensure that their u16 conversions do not unintentionally overlap.
+pub trait LayerId: Clone + Copy + PartialEq + Eq + Hash + Into<u16> {}
+
+impl LayerId for u16 {}

--- a/src/layer_builder.rs
+++ b/src/layer_builder.rs
@@ -1,5 +1,7 @@
 use crate::{
     chunk::ChunkBundle,
+    layer::LayerId,
+    map::MapId,
     morton_index,
     render::TilemapData,
     round_to_power_of_two,
@@ -30,11 +32,11 @@ where
     /// Creates the layer builder using the layer settings.
     /// The `pipeline` parameter allows you to pass in a custom RenderPipelines
     /// which will be used for rendering each chunk entity.
-    pub fn new<M: Into<u16>, L: Into<u16>>(
+    pub fn new(
         commands: &mut Commands,
         mut settings: LayerSettings,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
         pipeline: Option<RenderPipelines>,
     ) -> (Self, Entity) {
         let layer_entity = commands.spawn().id();
@@ -67,13 +69,13 @@ where
     /// Note: Limited to T(Bundle + TileBundleTrait) for what gets spawned.
     /// The `pipeline` parameter allows you to pass in a custom RenderPipelines
     /// which will be used for rendering each chunk entity.
-    pub fn new_batch<M: Into<u16>, L: Into<u16>, F: 'static + FnMut(TilePos) -> Option<T>>(
+    pub fn new_batch<F: 'static + FnMut(TilePos) -> Option<T>>(
         commands: &mut Commands,
         mut settings: LayerSettings,
         meshes: &mut ResMut<Assets<Mesh>>,
         material_handle: Handle<ColorMaterial>,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
         pipeline: Option<RenderPipelines>,
         mut f: F,
     ) -> Entity {

--- a/src/ldtk.rs
+++ b/src/ldtk.rs
@@ -162,12 +162,12 @@ pub fn process_loaded_tile_maps(
                 let default_grid_size = ldtk_map.project.default_grid_size;
                 let level = &ldtk_map.project.levels[map_config.selected_level];
 
-                let map_tile_count_x = (level.px_wid / default_grid_size) as u32;
-                let map_tile_count_y = (level.px_hei / default_grid_size) as u32;
+                let map_tile_count_x = (level.px_wid / default_grid_size) as usize;
+                let map_tile_count_y = (level.px_hei / default_grid_size) as usize;
 
                 let map_size = MapSize(
-                    (map_tile_count_x as f32 / 32.0).ceil() as u32,
-                    (map_tile_count_y as f32 / 32.0).ceil() as u32,
+                    (map_tile_count_x as f32 / 32.0).ceil() as usize,
+                    (map_tile_count_y as f32 / 32.0).ceil() as usize,
                 );
 
                 for (layer_id, layer) in level
@@ -200,15 +200,15 @@ pub fn process_loaded_tile_maps(
                         None,
                     );
 
-                    let tileset_width_in_tiles = (tileset.px_wid / default_grid_size) as u32;
+                    let tileset_width_in_tiles = (tileset.px_wid / default_grid_size) as usize;
 
                     for tile in layer.grid_tiles.iter() {
-                        let tileset_x = (tile.src[0] / default_grid_size) as u32;
-                        let tileset_y = (tile.src[1] / default_grid_size) as u32;
+                        let tileset_x = (tile.src[0] / default_grid_size) as usize;
+                        let tileset_y = (tile.src[1] / default_grid_size) as usize;
 
                         let mut pos = TilePos(
-                            (tile.px[0] / default_grid_size) as u32,
-                            (tile.px[1] / default_grid_size) as u32,
+                            (tile.px[0] / default_grid_size) as usize,
+                            (tile.px[1] / default_grid_size) as usize,
                         );
 
                         pos.1 = map_tile_count_y - pos.1 - 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,11 +210,11 @@ pub(crate) fn round_to_power_of_two(value: f32) -> usize {
 
 /// The size of the map, in chunks
 #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
-pub struct MapSize(pub u32, pub u32);
+pub struct MapSize(pub usize, pub usize);
 
 /// The size of each chunk, in tiles
 #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
-pub struct ChunkSize(pub u32, pub u32);
+pub struct ChunkSize(pub usize, pub usize);
 
 /// The size of each tile, in pixels
 #[derive(Default, Clone, Copy, PartialEq, Debug)]
@@ -246,17 +246,17 @@ impl Into<Vec2> for TextureSize {
 ///
 /// Coordinates start at (0, 0) from the bottom-left tile of the map.
 #[derive(Default, Clone, Copy, PartialEq, Eq, Debug, Hash)]
-pub struct TilePos(pub u32, pub u32);
+pub struct TilePos(pub usize, pub usize);
 
 impl Into<UVec2> for TilePos {
     fn into(self) -> UVec2 {
-        UVec2::new(self.0, self.1)
+        UVec2::new(self.0 as u32, self.1 as u32)
     }
 }
 
 impl Into<TilePos> for UVec2 {
     fn into(self) -> TilePos {
-        TilePos(self.x, self.y)
+        TilePos(self.x as usize, self.y as usize)
     }
 }
 
@@ -264,11 +264,11 @@ impl Into<TilePos> for UVec2 {
 ///
 /// Coordinates start at (0, 0) from the bottom-left tile of the chunk.
 #[derive(Default, Clone, Copy, PartialEq, Eq, Debug, Hash)]
-pub struct LocalTilePos(pub u32, pub u32);
+pub struct LocalTilePos(pub usize, pub usize);
 
 impl Into<UVec2> for LocalTilePos {
     fn into(self) -> UVec2 {
-        UVec2::new(self.0, self.1)
+        UVec2::new(self.0 as u32, self.1 as u32)
     }
 }
 
@@ -277,10 +277,10 @@ impl Into<UVec2> for LocalTilePos {
 /// Coordinates start at (0, 0) from the bottom-left chunk of the map.
 /// Note that these coordinates are measured in terms of chunks, not tiles.
 #[derive(Default, Clone, Copy, PartialEq, Eq, Debug, Hash)]
-pub struct ChunkPos(pub u32, pub u32);
+pub struct ChunkPos(pub usize, pub usize);
 
 impl Into<UVec2> for ChunkPos {
     fn into(self) -> UVec2 {
-        UVec2::new(self.0, self.1)
+        UVec2::new(self.0 as u32, self.1 as u32)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,9 +178,9 @@ fn morton_pos(index: usize) -> UVec2 {
 /// use bevy_ecs_tilemap::prelude::*; to import commonly used components, data structures, bundles, and plugins.
 pub mod prelude {
     pub use crate::chunk::{Chunk, ChunkSettings};
-    pub use crate::layer::{Layer, LayerBundle, LayerSettings, MapTileError};
+    pub use crate::layer::{Layer, LayerBundle, LayerId, LayerSettings, MapTileError};
     pub use crate::layer_builder::LayerBuilder;
-    pub use crate::map::Map;
+    pub use crate::map::{Map, MapId};
     pub use crate::map_query::MapQuery;
     pub(crate) use crate::mesher::ChunkMesher;
     pub use crate::tile::{GPUAnimated, Tile, TileBundle, TileBundleTrait, TileParent};

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,4 +1,6 @@
+use crate::layer::LayerId;
 use bevy::prelude::*;
+use std::hash::Hash;
 use std::{collections::HashMap, vec::IntoIter};
 
 /// A simple component used to keep track of layer entities.
@@ -21,7 +23,7 @@ impl Default for Map {
 
 impl Map {
     /// Creates a new map component
-    pub fn new<M: Into<u16>>(id: M, map_entity: Entity) -> Self {
+    pub fn new(id: impl MapId, map_entity: Entity) -> Self {
         Self {
             map_entity,
             id: id.into(),
@@ -30,10 +32,10 @@ impl Map {
     }
 
     /// Creates a new layer.
-    pub fn add_layer<L: Into<u16>>(
+    pub fn add_layer(
         &mut self,
         commands: &mut Commands,
-        layer_id: L,
+        layer_id: impl LayerId,
         layer_entity: Entity,
     ) {
         commands
@@ -43,10 +45,10 @@ impl Map {
     }
 
     /// Adds multiple layers to the map.
-    pub fn add_layers<L: Into<u16>>(
+    pub fn add_layers(
         &mut self,
         commands: &mut Commands,
-        layers: IntoIter<(L, Entity)>,
+        layers: IntoIter<(impl LayerId, Entity)>,
     ) {
         let layers: Vec<(u16, Entity)> = layers.map(|(id, entity)| (id.into(), entity)).collect();
         let entities: Vec<Entity> = layers.iter().map(|(_, entity)| *entity).collect();
@@ -56,7 +58,7 @@ impl Map {
 
     /// Removes the layer from the map and despawns the layer entity.
     /// Note: Does not despawn the tile entities. Please use MapQuery instead.
-    pub fn remove_layer<L: Into<u16>>(&mut self, commands: &mut Commands, layer_id: L) {
+    pub fn remove_layer(&mut self, commands: &mut Commands, layer_id: impl LayerId) {
         if let Some(layer_entity) = self.layers.remove(&layer_id.into()) {
             commands.entity(layer_entity).despawn_recursive();
         }
@@ -64,7 +66,7 @@ impl Map {
 
     /// Removes the layers from the map and despawns the layer entities.
     /// Note: Does not despawn the tile entities. Please use MapQuery instead.
-    pub fn remove_layers<L: Into<u16>>(&mut self, commands: &mut Commands, layers: IntoIter<L>) {
+    pub fn remove_layers(&mut self, commands: &mut Commands, layers: IntoIter<impl LayerId>) {
         layers.for_each(|id| {
             let id: u16 = id.into();
             self.remove_layer(commands, id);
@@ -72,7 +74,7 @@ impl Map {
     }
 
     /// Retrieves the entity for a given layer id.
-    pub fn get_layer_entity<L: Into<u16>>(&self, layer_id: L) -> Option<&Entity> {
+    pub fn get_layer_entity(&self, layer_id: impl LayerId) -> Option<&Entity> {
         self.layers.get(&layer_id.into())
     }
 
@@ -88,3 +90,11 @@ impl Map {
             .collect()
     }
 }
+
+/// A type that can be used to identify which map a tile is in.
+///
+/// These are ultimately converted to u16; if you're using more than one type with this trait in your game,
+/// ensure that their u16 conversions do not unintentionally overlap.
+pub trait MapId: Clone + Copy + PartialEq + Eq + Hash + Into<u16> {}
+
+impl MapId for u16 {}

--- a/src/map_query.rs
+++ b/src/map_query.rs
@@ -63,13 +63,13 @@ impl<'a> MapQuery<'a> {
     ///   tile.texture_index = 10;
     /// }
     /// ```
-    pub fn set_tile<M: Into<u16> + Copy, L: Into<u16> + Copy>(
+    pub fn set_tile(
         &mut self,
         commands: &mut Commands,
         tile_pos: TilePos,
         tile: Tile,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) -> Result<Entity, MapTileError> {
         let map_id = map_id.into();
         let layer_id = layer_id.into();
@@ -117,10 +117,10 @@ impl<'a> MapQuery<'a> {
         Err(MapTileError::OutOfBounds)
     }
 
-    pub fn get_layer<M: Into<u16>, L: Into<u16>>(
+    pub fn get_layer(
         &self,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) -> Option<(Entity, &Layer)> {
         let map_id = map_id.into();
         let layer_id = layer_id.into();
@@ -141,11 +141,11 @@ impl<'a> MapQuery<'a> {
     }
 
     /// Gets a tile entity for the given position and layer_id returns an error if OOB or the tile doesn't exist.
-    pub fn get_tile_entity<M: Into<u16> + Copy, L: Into<u16> + Copy>(
+    pub fn get_tile_entity(
         &self,
         tile_pos: TilePos,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) -> Result<Entity, MapTileError> {
         let map_id = map_id.into();
         let layer_id = layer_id.into();
@@ -179,12 +179,12 @@ impl<'a> MapQuery<'a> {
     }
 
     /// Despawns the tile entity and removes it from the layer/chunk cache.
-    pub fn despawn_tile<M: Into<u16>, L: Into<u16>>(
+    pub fn despawn_tile(
         &mut self,
         commands: &mut Commands,
         tile_pos: TilePos,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) -> Result<(), MapTileError> {
         let map_id = map_id.into();
         let layer_id = layer_id.into();
@@ -223,11 +223,11 @@ impl<'a> MapQuery<'a> {
 
     /// Despawns all of the tiles in a layer.
     /// Note: Doesn't despawn the layer.
-    pub fn despawn_layer_tiles<M: Into<u16>, L: Into<u16>>(
+    pub fn despawn_layer_tiles(
         &mut self,
         commands: &mut Commands,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) {
         let map_id = map_id.into();
         let layer_id = layer_id.into();
@@ -266,11 +266,11 @@ impl<'a> MapQuery<'a> {
     }
 
     /// Despawns a layer completely including all tiles.
-    pub fn despawn_layer<M: Into<u16>, L: Into<u16>>(
+    pub fn despawn_layer(
         &mut self,
         commands: &mut Commands,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) {
         let map_id = map_id.into();
         let layer_id = layer_id.into();
@@ -298,7 +298,7 @@ impl<'a> MapQuery<'a> {
     }
 
     /// Despawn an entire map including all layers/tiles.
-    pub fn despawn<M: Into<u16>>(&mut self, commands: &mut Commands, map_id: M) {
+    pub fn despawn(&mut self, commands: &mut Commands, map_id: impl MapId) {
         let map_id: u16 = map_id.into();
 
         let layer_ids: Option<Vec<u16>> = if let Some((_, map)) = self
@@ -328,14 +328,14 @@ impl<'a> MapQuery<'a> {
         }
     }
 
-    /// Lets the internal systems know to "remesh" the chunk.
+    /// Let's the internal systems know to "remesh" the chunk.
     pub fn notify_chunk(&mut self, chunk_entity: Entity) {
         if let Ok((_, mut chunk)) = self.chunk_query_set.q0_mut().get_mut(chunk_entity) {
             chunk.needs_remesh = true;
         }
     }
 
-    /// Lets the internal systems know to remesh the chunk for a given tile pos and layer_id.
+    /// Let's the internal systems know to remesh the chunk for a given tile pos and layer_id.
     pub fn notify_chunk_for_tile<M: Into<u16>, L: Into<u16>>(
         &mut self,
         tile_pos: TilePos,

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -63,9 +63,9 @@ impl<'a> MapQuery<'a> {
 /// Gets the positions of the neighbors of the specified position
 /// Order: N, S, W, E, NW, NE, SW, SE.
 ///
-/// Tile positions are bounded between 0 and u32::MAX, so None may be returned
+/// Tile positions are bounded between 0 and usize::MAX, so None may be returned
 pub fn get_neighboring_pos(tile_pos: TilePos) -> [Option<TilePos>; 8] {
-    let north = if tile_pos.1 != u32::MAX {
+    let north = if tile_pos.1 != usize::MAX {
         Some(TilePos(tile_pos.0, tile_pos.1 + 1))
     } else {
         None
@@ -83,19 +83,19 @@ pub fn get_neighboring_pos(tile_pos: TilePos) -> [Option<TilePos>; 8] {
         None
     };
 
-    let east = if tile_pos.0 != u32::MAX {
+    let east = if tile_pos.0 != usize::MAX {
         Some(TilePos(tile_pos.0 + 1, tile_pos.1))
     } else {
         None
     };
 
-    let northwest = if (tile_pos.0 != 0) & (tile_pos.1 != u32::MAX) {
+    let northwest = if (tile_pos.0 != 0) & (tile_pos.1 != usize::MAX) {
         Some(TilePos(tile_pos.0 - 1, tile_pos.1 + 1))
     } else {
         None
     };
 
-    let northeast = if (tile_pos.0 != u32::MAX) & (tile_pos.1 != u32::MAX) {
+    let northeast = if (tile_pos.0 != usize::MAX) & (tile_pos.1 != usize::MAX) {
         Some(TilePos(tile_pos.0 + 1, tile_pos.1 + 1))
     } else {
         None
@@ -107,7 +107,7 @@ pub fn get_neighboring_pos(tile_pos: TilePos) -> [Option<TilePos>; 8] {
         None
     };
 
-    let southeast = if (tile_pos.0 != u32::MAX) & (tile_pos.1 != 0) {
+    let southeast = if (tile_pos.0 != usize::MAX) & (tile_pos.1 != 0) {
         Some(TilePos(tile_pos.0 + 1, tile_pos.1 - 1))
     } else {
         None

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -1,5 +1,6 @@
-use crate::layer::MapTileError;
+use crate::layer::{LayerId, MapTileError};
 use crate::layer_builder::LayerBuilder;
+use crate::map::MapId;
 use crate::map_query::MapQuery;
 use crate::tile::TileBundleTrait;
 use crate::TilePos;
@@ -41,11 +42,11 @@ impl<'a> MapQuery<'a> {
     /// assert!(neighbors[1].1.is_none()); // Outside of tile bounds.
     /// assert!(neighbors[0].1.is_none()); // Entity returned inside bounds.
     /// ```
-    pub fn get_tile_neighbors<M: Into<u16> + Copy, L: Into<u16> + Copy>(
+    pub fn get_tile_neighbors(
         &self,
         tile_pos: TilePos,
-        map_id: M,
-        layer_id: L,
+        map_id: impl MapId,
+        layer_id: impl LayerId,
     ) -> Vec<Result<Entity, MapTileError>> {
         let neighboring_tile_pos = get_neighboring_pos(tile_pos);
 

--- a/src/tiled.rs
+++ b/src/tiled.rs
@@ -150,8 +150,8 @@ pub fn process_loaded_tile_maps(
 
                         let mut map_settings = LayerSettings::new(
                             MapSize(
-                                (tiled_map.map.width as f32 / 64.0).ceil() as u32,
-                                (tiled_map.map.height as f32 / 64.0).ceil() as u32,
+                                (tiled_map.map.width as f32 / 64.0).ceil() as usize,
+                                (tiled_map.map.height as f32 / 64.0).ceil() as usize,
                             ),
                             ChunkSize(64, 64),
                             TileSize(tile_width, tile_height),
@@ -190,18 +190,18 @@ pub fn process_loaded_tile_maps(
                             layer.layer_index as u16,
                             None,
                             move |mut tile_pos| {
-                                if tile_pos.0 >= tiled_map_data.width
-                                    || tile_pos.1 >= tiled_map_data.height
+                                if tile_pos.0 >= tiled_map_data.width as usize
+                                    || tile_pos.1 >= tiled_map_data.height as usize
                                 {
                                     return None;
                                 }
 
                                 if tiled_map_data.orientation == tiled::Orientation::Orthogonal {
-                                    tile_pos.1 = (tiled_map_data.height - 1) as u32 - tile_pos.1;
+                                    tile_pos.1 = (tiled_map_data.height - 1) as usize - tile_pos.1;
                                 }
 
-                                let x = tile_pos.0 as usize;
-                                let y = tile_pos.1 as usize;
+                                let x = tile_pos.0;
+                                let y = tile_pos.1;
 
                                 let map_tile = match &layer_data.tiles {
                                     tiled::LayerData::Finite(tiles) => &tiles[y][x],


### PR DESCRIPTION
Fixes #95.

This will make the end-user API dramatically nicer (and hopefully faster) when interfacing with resources that want to be accessed by `TilePos` coordinates.

Incidentally, this also expands the maximum size of the map to `u64` in most cases. This is almost certainly a *bad* idea for users to take advantage of though, as 2^32 tiles is already monstrous and Bevy will run out of `Entity` IDs to take advantage of.

There are two main drawbacks here:
  - doubles the memory footprint of coordinates. `MapSize` etc are irrelevant here, but `TilePos` is not
  - forces a more expensive conversion to `UVec2` API. It's not immediately clear to me that we need `UVec2` at all in the stack, but I didn't dig deep enough to investigate. Without a solid set of benchmarks to run, I'm reluctant to try to make perf-driven changes like this.
  
If these drawbacks are too severe; we could work around this in end user code by doing the conversions there, probably with a decent API.  This incurs a different set of reasonably serious perf trade-offs, but will only be relevant in some end user applications.