### PR TITLE
Optimize Tiled example asset dependencies

### DIFF
--- a/examples/helpers/mod.rs
+++ b/examples/helpers/mod.rs
@@ -1,3 +1,3 @@
 pub mod camera;
-pub mod texture;
 pub mod movement;
+pub mod texture;


### PR DESCRIPTION
I have a Tiled map with a single 16x16 tileset.

Prior to this PR, the Tiled example would create an identical `AssetPath` and add it as an asset dependency 256 times. I haven't looked into the details, but bevy was not handling this well as one would hope, and there seemed to be a noticeable slowdown.

This seems to resolve the issue.