### PR TITLE
Fixed Animation Indexing

### DIFF
--- a/src/render/columnevenhex-tilemap.vert
+++ b/src/render/columnevenhex-tilemap.vert
@@ -53,7 +53,7 @@ void main() {
 
     float current_animation_frame = fract(time * Vertex_Position.z) * frames;
 
-    current_animation_frame = clamp(current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
+    current_animation_frame = clamp(float(Vertex_Texture.z) + current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
 
     int texture_index = int(current_animation_frame);
     

--- a/src/render/columnhex-tilemap.vert
+++ b/src/render/columnhex-tilemap.vert
@@ -48,7 +48,7 @@ void main() {
 
     float current_animation_frame = fract(time * Vertex_Position.z) * frames;
 
-    current_animation_frame = clamp(current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
+    current_animation_frame = clamp(float(Vertex_Texture.z) + current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
 
     int texture_index = int(current_animation_frame);
     

--- a/src/render/columnoddhex-tilemap.vert
+++ b/src/render/columnoddhex-tilemap.vert
@@ -53,7 +53,7 @@ void main() {
 
     float current_animation_frame = fract(time * Vertex_Position.z) * frames;
 
-    current_animation_frame = clamp(current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
+    current_animation_frame = clamp(float(Vertex_Texture.z) + current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
 
     int texture_index = int(current_animation_frame);
     

--- a/src/render/diamondiso-tilemap.vert
+++ b/src/render/diamondiso-tilemap.vert
@@ -55,7 +55,7 @@ void main() {
 
     float current_animation_frame = fract(time * Vertex_Position.z) * frames;
 
-    current_animation_frame = clamp(current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
+    current_animation_frame = clamp(float(Vertex_Texture.z) + current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
 
     int texture_index = int(current_animation_frame);
     

--- a/src/render/rowevenhex-tilemap.vert
+++ b/src/render/rowevenhex-tilemap.vert
@@ -53,7 +53,7 @@ void main() {
 
     float current_animation_frame = fract(time * Vertex_Position.z) * frames;
 
-    current_animation_frame = clamp(current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
+    current_animation_frame = clamp(float(Vertex_Texture.z) + current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
 
     int texture_index = int(current_animation_frame);
     

--- a/src/render/rowhex-tilemap.vert
+++ b/src/render/rowhex-tilemap.vert
@@ -48,7 +48,7 @@ void main() {
 
     float current_animation_frame = fract(time * Vertex_Position.z) * frames;
 
-    current_animation_frame = clamp(current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
+    current_animation_frame = clamp(float(Vertex_Texture.z) + current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
 
     int texture_index = int(current_animation_frame);
 

--- a/src/render/rowoddhex-tilemap.vert
+++ b/src/render/rowoddhex-tilemap.vert
@@ -53,7 +53,7 @@ void main() {
 
     float current_animation_frame = fract(time * Vertex_Position.z) * frames;
 
-    current_animation_frame = clamp(current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
+    current_animation_frame = clamp(float(Vertex_Texture.z) + current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
 
     int texture_index = int(current_animation_frame);
     

--- a/src/render/square-tilemap.vert
+++ b/src/render/square-tilemap.vert
@@ -42,7 +42,7 @@ void main() {
 
     float current_animation_frame = fract(time * Vertex_Position.z) * frames;
 
-    current_animation_frame = clamp(current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
+    current_animation_frame = clamp(float(Vertex_Texture.z) + current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
 
     int texture_index = int(current_animation_frame);
 

--- a/src/render/staggerediso-tilemap.vert
+++ b/src/render/staggerediso-tilemap.vert
@@ -60,7 +60,7 @@ void main() {
 
     float current_animation_frame = fract(time * Vertex_Position.z) * frames;
 
-    current_animation_frame = clamp(current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
+    current_animation_frame = clamp(float(Vertex_Texture.z) + current_animation_frame, float(Vertex_Texture.z), float(Vertex_Texture.w));
 
     int texture_index = int(current_animation_frame);
     

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -42,9 +42,9 @@ impl Into<TileBundle> for Tile {
 /// Currently all frames must be aligned in your tilemap.
 #[derive(Debug, Clone, Copy)]
 pub struct GPUAnimated {
-    /// The start frame index in the tilemap atlas/array.
+    /// The start frame index in the tilemap atlas/array (inclusive).
     pub start: u32,
-    /// The end frame index in the tilemap atlas/array.
+    /// The end frame index in the tilemap atlas/array (exclusive).
     pub end: u32,
     /// The speed the animation plays back at.
     pub speed: f32,


### PR DESCRIPTION
The current animation frame was calculated by getting the offset from the start index. However, when this was used, it wasn't added to the start index.

Essentially, changed:
```glsl
current_animation_frame = clamp(current_animation_frame, start, end);
```
To:
```glsl
current_animation_frame = clamp(start + current_animation_frame, start, end);
```
<br/>

Also updated documentation to reflect the fact that `GPUAnimated`'s `end` index is exclusive.

Resolves #116.