### PR TITLE
Improved System Labels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,14 @@ impl Default for TilemapMeshType {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, StageLabel)]
 pub struct TilemapStage;
 
+/// The tilemap system labels
+#[derive(Debug, Clone, PartialEq, Eq, Hash, SystemLabel)]
+pub enum TilemapLabel {
+    UpdateChunkHashmap,
+    UpdateChunkVisibility,
+    UpdateChunkMesh,
+}
+
 impl Plugin for TilemapPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_stage_before(CoreStage::PostUpdate, TilemapStage, SystemStage::parallel())
@@ -129,20 +137,21 @@ impl Plugin for TilemapPlugin {
                 TilemapStage,
                 update_chunk_hashmap_for_added_tiles
                     .system()
-                    .label("hash_update_for_tiles"),
+                    .label(TilemapLabel::UpdateChunkHashmap),
             )
             .add_system_to_stage(
                 TilemapStage,
                 update_chunk_visibility
                     .system()
-                    .label("update_chunk_visibility"),
+                    .label(TilemapLabel::UpdateChunkVisibility),
             )
             .add_system_to_stage(
                 TilemapStage,
                 update_chunk_mesh
                     .system()
-                    .after("hash_update_for_tiles")
-                    .after("update_chunk_visibility"),
+                    .label(TilemapLabel::UpdateChunkMesh)
+                    .after(TilemapLabel::UpdateChunkHashmap)
+                    .after(TilemapLabel::UpdateChunkVisibility),
             );
         let world = app.world_mut();
         add_tile_map_graph(world);


### PR DESCRIPTION
Updated the system labels to use an enum instead of strings. This should help reduce collisions (though, that wasn't likely to begin with) and allow users to insert their own systems between these internal ones, which may be helpful for manipulating tiles and chunks between these systems.