### PR TITLE
Get by Entity functions for MapQuery

### DIFF
--- a/src/map_query.rs
+++ b/src/map_query.rs
@@ -142,6 +142,22 @@ impl<'a> MapQuery<'a> {
         None
     }
 
+    pub fn get_layer_by_entity(&self, entity: Entity) -> Option<&Layer> {
+        self.layer_query_set
+            .q1()
+            .get(entity)
+            .ok()
+            .map(|(_, layer)| layer)
+    }
+
+    pub fn get_layer_by_entity_mut(&mut self, entity: Entity) -> Option<Mut<Layer>> {
+        self.layer_query_set
+            .q0_mut()
+            .get_mut(entity)
+            .ok()
+            .map(|(_, layer)| layer)
+    }
+
     /// Gets a tile entity for the given position and layer_id returns an error if OOB or the tile doesn't exist.
     pub fn get_tile_entity(
         &self,
@@ -416,6 +432,34 @@ impl<'a> MapQuery<'a> {
         }
 
         0.0
+    }
+
+    pub fn get_chunk_by_entity(&self, entity: Entity) -> Option<&Chunk> {
+        self.chunk_query_set
+            .q1()
+            .get(entity)
+            .ok()
+            .map(|(_, chunk)| chunk)
+    }
+
+    pub fn get_chunk_by_entity_mut(&mut self, entity: Entity) -> Option<Mut<Chunk>> {
+        self.chunk_query_set
+            .q0_mut()
+            .get_mut(entity)
+            .ok()
+            .map(|(_, chunk)| chunk)
+    }
+
+    pub fn get_map_by_entity(&self, entity: Entity) -> Option<&Map> {
+        self.map_query_set.q1().get(entity).ok().map(|(_, map)| map)
+    }
+
+    pub fn get_map_by_entity_mut(&mut self, entity: Entity) -> Option<Mut<Map>> {
+        self.map_query_set
+            .q0_mut()
+            .get_mut(entity)
+            .ok()
+            .map(|(_, map)| map)
     }
 }
 


### PR DESCRIPTION
For my game, I need to be able to get a `Layer` (for its `LayerSettings`) by its `Entity`, in the same system where I'm using `MapQuery`, but I cannot do so, since `Query<&Layer>` conflicts with `MapQuery`. I've added functions to `MapQuery` to get `Layers` by their `Entity`s, mutably or immutably. I also added similar functions for `Map`s and `Chunk`s, since a similar problem could occur with those.

Alternatively, in my game, I could store my `Layer`s' `u16` IDs in the place of their `Entity`s, but I did not want to have to use `MapQuery` in systems that do not need it, for the sake of better parallelism, and I didn't think such a restriction was intended, so I decided to suggest the addition of these functions. Also, I wanted to avoid the O(N) operations of finding layers by ID.

Another solution could be to add some sort of variant of `Commands` (`MapCommands`?), replacing the need for mutable `Query`s in `MapQuery`, and avoiding this issue, as long as the user does not need to mutably query `Layer`s, etc. This would take significantly more work.

Lmk if a different solution is desired. Also lmk if this solution is desired, because I have only slightly tested that these functions work.

Thank you!