### PR TITLE
Fix panic

### DIFF
--- a/src/render/pipeline.rs
+++ b/src/render/pipeline.rs
@@ -67,21 +67,24 @@ pub fn extract_tilemaps(
         &TilemapUniformData,
         &Handle<Mesh>,
     )>,
+    images: Res<Assets<Image>>,
 ) {
     let mut extracted_tilemaps = Vec::new();
     for (entity, transform, chunk, tilemap_uniform, mesh_handle) in query.iter() {
-        let transform = transform.compute_matrix();
-        extracted_tilemaps.push((
-            entity,
-            (
-                LayerId(chunk.settings.layer_id),
-                chunk.material.clone(),
-                chunk.settings.mesh_type.clone(),
-                mesh_handle.clone_weak(),
-                tilemap_uniform.clone(),
-                MeshUniform { transform },
-            ),
-        ));
+        if images.get(&chunk.material).is_some() {
+            let transform = transform.compute_matrix();
+            extracted_tilemaps.push((
+                entity,
+                (
+                    LayerId(chunk.settings.layer_id),
+                    chunk.material.clone(),
+                    chunk.settings.mesh_type.clone(),
+                    mesh_handle.clone_weak(),
+                    tilemap_uniform.clone(),
+                    MeshUniform { transform },
+                ),
+            ));
+        }
     }
     commands.insert_or_spawn_batch(extracted_tilemaps);
 }


### PR DESCRIPTION
Fixes #125

This seems to make some sense to me, and I came to this change by looking at the extract function in `bevy_sprite`. But I'm not really up to speed on the new renderer yet so I am not very confident that this is correct.

Either way, it fixes the panic I was seeing both in the minimal repro and in my game.