### PR TITLE
Move wasm32 runner to correct config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = "wasm-server-runner"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,3 @@ path = "examples/tiled/tiled_usage.rs"
 [[example]]
 name = "tiled_rotate"
 path = "examples/tiled/tiled_rotate.rs"
-
-[target.wasm32-unknown-unknown]
-runner = "wasm-server-runner"


### PR DESCRIPTION
The runner for target.wasm32-unknown-unknown has to be specified in the cargo config file (not the package configuration file).

Added the config file in `.cargo/config.toml`.

So examples can be run on wasm32 using wasm-server-runner this way:
`cargo run --release --target wasm32-unknown-unknown --example hex_row`