### PR TITLE
Remove dbg! call from `get_zindex_for_pixel_pos`

### DIFF
--- a/src/map_query.rs
+++ b/src/map_query.rs
@@ -422,7 +422,6 @@ impl<'w, 's> MapQuery<'w, 's> {
                         grid_size.x,
                         grid_size.y,
                     );
-                    dbg!(grid_size, layer_size_in_tiles, map_size, map_pos, center);
 
                     return pixel_position.z + (1.0 - (center.y / map_size.y));
                 }


### PR DESCRIPTION
This call was introduced in #139 along with a few others, I assume accidentally? I ignored the ones within the `examples` folder, but since this is in the library itself it has been spamming my console.