### PR TITLE
Implemented `Error` on `MapTileError`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,24 @@
+use crate::TilePos;
+
+/// General errors that are returned by bevy_ecs_tilemap.
+#[derive(Debug, Copy, Clone)]
+pub enum MapTileError {
+    /// The tile was out of bounds.
+    OutOfBounds(TilePos),
+    /// The tile already exists.
+    AlreadyExists(TilePos),
+    /// Doesn't exist
+    NonExistent(TilePos),
+}
+
+impl std::error::Error for MapTileError {}
+
+impl std::fmt::Display for MapTileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            MapTileError::OutOfBounds(pos) => write!(f, "Tile out of bounds (@ {:?})", pos),
+            MapTileError::AlreadyExists(pos) => write!(f, "Tile already exists (@ {:?})", pos),
+            MapTileError::NonExistent(pos) => write!(f, "Tile does not exist (@ {:?})", pos),
+        }
+    }
+}

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -108,11 +108,22 @@ pub struct Layer {
 #[derive(Debug, Copy, Clone)]
 pub enum MapTileError {
     /// The tile was out of bounds.
-    OutOfBounds,
+    OutOfBounds(TilePos),
     /// The tile already exists.
-    AlreadyExists,
+    AlreadyExists(TilePos),
     /// Doesn't exist
-    NonExistent,
+    NonExistent(TilePos),
+}
+
+impl std::error::Error for MapTileError {}
+impl std::fmt::Display for MapTileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            MapTileError::OutOfBounds(pos) => write!(f, "Tile out of bounds (@ {:?})", pos),
+            MapTileError::AlreadyExists(pos) => write!(f, "Tile already exists (@ {:?})", pos),
+            MapTileError::NonExistent(pos) => write!(f, "Tile does not exist (@ {:?})", pos),
+        }
+    }
 }
 
 impl Layer {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -104,28 +104,6 @@ pub struct Layer {
     pub(crate) chunks: Vec<Option<Entity>>,
 }
 
-/// General errors that are returned by bevy_ecs_tilemap.
-#[derive(Debug, Copy, Clone)]
-pub enum MapTileError {
-    /// The tile was out of bounds.
-    OutOfBounds(TilePos),
-    /// The tile already exists.
-    AlreadyExists(TilePos),
-    /// Doesn't exist
-    NonExistent(TilePos),
-}
-
-impl std::error::Error for MapTileError {}
-impl std::fmt::Display for MapTileError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            MapTileError::OutOfBounds(pos) => write!(f, "Tile out of bounds (@ {:?})", pos),
-            MapTileError::AlreadyExists(pos) => write!(f, "Tile already exists (@ {:?})", pos),
-            MapTileError::NonExistent(pos) => write!(f, "Tile does not exist (@ {:?})", pos),
-        }
-    }
-}
-
 impl Layer {
     /// Creates a new map component.
     ///

--- a/src/layer_builder.rs
+++ b/src/layer_builder.rs
@@ -174,7 +174,7 @@ where
             self.tiles[morton_tile_index].1 = Some(tile);
             return Ok(());
         }
-        Err(MapTileError::OutOfBounds)
+        Err(MapTileError::OutOfBounds(tile_pos))
     }
 
     /// Returns an existing tile entity or spawns a new one.
@@ -196,7 +196,7 @@ where
             return Ok(tile_entity.unwrap());
         }
 
-        Err(MapTileError::OutOfBounds)
+        Err(MapTileError::OutOfBounds(tile_pos))
     }
 
     /// Returns an existing tile entity if it exists
@@ -229,10 +229,10 @@ where
             if let Some(tile) = &self.tiles[morton_tile_index].1 {
                 return Ok(tile);
             } else {
-                return Err(MapTileError::NonExistent);
+                return Err(MapTileError::NonExistent(tile_pos));
             }
         }
-        Err(MapTileError::OutOfBounds)
+        Err(MapTileError::OutOfBounds(tile_pos))
     }
 
     /// Gets a mutable reference to the tile data using the a tile position.
@@ -242,10 +242,10 @@ where
             if let Some(tile) = &mut self.tiles[morton_tile_index].1 {
                 return Ok(tile);
             } else {
-                return Err(MapTileError::NonExistent);
+                return Err(MapTileError::NonExistent(tile_pos));
             }
         }
-        Err(MapTileError::OutOfBounds)
+        Err(MapTileError::OutOfBounds(tile_pos))
     }
 
     /// Loops through each tile entity and tile bundle in the builder.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ use chunk::{update_chunk_mesh, update_chunk_time, update_chunk_visibility};
 use layer::update_chunk_hashmap_for_added_tiles;
 
 mod chunk;
+mod error;
 mod layer;
 mod layer_builder;
 mod map;
@@ -72,7 +73,8 @@ mod tile;
 mod tile_atlas;
 
 pub use crate::chunk::Chunk;
-pub use crate::layer::{Layer, LayerBundle, LayerSettings, MapTileError};
+pub use crate::error::MapTileError;
+pub use crate::layer::{Layer, LayerBundle, LayerSettings};
 pub use crate::layer_builder::LayerBuilder;
 pub use crate::map::Map;
 pub use crate::map_query::MapQuery;
@@ -171,7 +173,8 @@ fn get_tile_pos_from_index(index: usize, width: u32) -> UVec2 {
 /// use bevy_ecs_tilemap::prelude::*; to import commonly used components, data structures, bundles, and plugins.
 pub mod prelude {
     pub use crate::chunk::Chunk;
-    pub use crate::layer::{Layer, LayerBundle, LayerSettings, MapTileError};
+    pub use crate::error::MapTileError;
+    pub use crate::layer::{Layer, LayerBundle, LayerSettings};
     pub use crate::layer_builder::LayerBuilder;
     pub use crate::map::{Map, MapId};
     pub use crate::map_query::MapQuery;

--- a/src/map_query.rs
+++ b/src/map_query.rs
@@ -131,7 +131,7 @@ impl<'w, 's> MapQuery<'w, 's> {
                 }
             }
         }
-        Err(MapTileError::OutOfBounds)
+        Err(MapTileError::OutOfBounds(tile_pos))
     }
 
     pub fn get_layer(
@@ -184,7 +184,7 @@ impl<'w, 's> MapQuery<'w, 's> {
                             {
                                 return Ok(tile);
                             } else {
-                                return Err(MapTileError::NonExistent);
+                                return Err(MapTileError::NonExistent(tile_pos));
                             }
                         }
                     }
@@ -192,7 +192,7 @@ impl<'w, 's> MapQuery<'w, 's> {
             }
         }
 
-        Err(MapTileError::OutOfBounds)
+        Err(MapTileError::OutOfBounds(tile_pos))
     }
 
     pub fn update_chunk<F: FnMut(Mut<Chunk>)>(&mut self, chunk_entity: Entity, mut f: F) {
@@ -234,14 +234,14 @@ impl<'w, 's> MapQuery<'w, 's> {
                                 chunk.tiles[morton_tile_index] = None;
                                 return Ok(());
                             } else {
-                                return Err(MapTileError::NonExistent);
+                                return Err(MapTileError::NonExistent(tile_pos));
                             }
                         }
                     }
                 }
             }
         }
-        Err(MapTileError::OutOfBounds)
+        Err(MapTileError::OutOfBounds(tile_pos))
     }
 
     /// Despawns all of the tiles in a layer.

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -54,7 +54,7 @@ impl<'w, 's> MapQuery<'w, 's> {
             .iter_mut()
             .map(|maybe_pos| match maybe_pos {
                 Some(pos) => self.get_tile_entity(*pos, map_id, layer_id),
-                _ => Err(MapTileError::OutOfBounds),
+                _ => Err(MapTileError::OutOfBounds(tile_pos)),
             })
             .collect::<Vec<_>>()
     }

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -1,4 +1,5 @@
-use crate::layer::{LayerId, MapTileError};
+use crate::error::MapTileError;
+use crate::layer::LayerId;
 use crate::layer_builder::LayerBuilder;
 use crate::map::MapId;
 use crate::map_query::MapQuery;


### PR DESCRIPTION
## Objective

Implement `Error` on `MapTileError` so that it can be used externally as a `dyn Error` type.

## Additional Changes

Added `TilePos` to all current variants since that can be helpful when tracking down which tile caused the error.

Also moved `MapTileError` to its own module (`error`). Before it was placed in the `layer` module but was used by other modules (`layer_builder`, `map_query`, etc.).