### PR TITLE
Convert tile colors to linear RGBA

### DIFF
--- a/src/mesher.rs
+++ b/src/mesher.rs
@@ -70,32 +70,8 @@ impl ChunkMesher {
                         [tile_pos.x, tile_pos.y, animation_speed],
                     ]));
 
-                    colors.extend(IntoIter::new([
-                        [
-                            tile.color.r(),
-                            tile.color.g(),
-                            tile.color.b(),
-                            tile.color.a(),
-                        ],
-                        [
-                            tile.color.r(),
-                            tile.color.g(),
-                            tile.color.b(),
-                            tile.color.a(),
-                        ],
-                        [
-                            tile.color.r(),
-                            tile.color.g(),
-                            tile.color.b(),
-                            tile.color.a(),
-                        ],
-                        [
-                            tile.color.r(),
-                            tile.color.g(),
-                            tile.color.b(),
-                            tile.color.a(),
-                        ],
-                    ]));
+                    let color_f32 = tile.color.as_linear_rgba_f32();
+                    colors.extend([color_f32, color_f32, color_f32, color_f32]);
 
                     // flipping and rotation packed in bits
                     // bit 0 : flip_x


### PR DESCRIPTION
Tile colors must be converted to linear RGBA, otherwise dark colors will
be significantly too bright. This matches the handling of Sprite::color in
bevy_sprite.

While we're at it, also simplify the code a bit.