### PR TITLE
Strip down bevy features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 atlas = []
 
 [dependencies]
-bevy = { version = "0.6", default-features = false, features = ["render"] }
+bevy = { version = "0.6", default-features = false, features = ["bevy_render","bevy_core_pipeline","bevy_sprite"] }
 log = "0.4"
 regex = "1.5.4"
 bytemuck = "1.7.2"


### PR DESCRIPTION
This crate does not need the full set of bevy render features (which includes 3d/bevy_pbr and bevy_ui).

Specifying the exact features needed allows users of this crate to remove the 3d/ui parts of bevy if they want.