### PR TITLE
update bevy_ecs 0.6.0->0.6.1 to fix compile error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b182092396e6c2caf5ab30d738511fcd382628aa86ef35878d28fabb325c933"
+checksum = "6daf05da2680a14b17a4b669879fa7186abb80e7fbe400fb02c0c62628d1e200"
 dependencies = [
  "async-channel",
  "bevy_ecs_macros",


### PR DESCRIPTION
I just checked out this project for the first time, and ran into a compile error from bevy_ecs.  This updates from 0.6.0 to 0.6.1, which fixes the error.

Here's the error:

```
$ cargo +nightly run --release --example map                                                                                  
warning: unused manifest key: target.wasm32-unknown-unknown.runner                                                            
   Compiling gltf-json v0.16.0                                                                                                
   Compiling ldtk_rust v0.5.2                                                                                                 
   Compiling bevy_ecs v0.6.0                                                                                                  
   Compiling wgpu-core v0.12.1                                                                                                
error: format argument must be a string literal                                                                               
   --> /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/bevy_ecs-0.6.0/src/schedule/executor_parallel.rs:135:66 
    |                                                                                                                         
135 | ...                   .unwrap_or_else(|error| unreachable!(error));                                                     
    |                                                            ^^^^^                                                        
    |                                                                                                                         
help: you might be missing a string literal to format with                                                                    
    |                                                                                                                         
135 |                             .unwrap_or_else(|error| unreachable!("{}", error));                                         
    |                                                                  +++++                                                  
                                                                                                                              
error: format argument must be a string literal                                                                               
   --> /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/bevy_ecs-0.6.0/src/schedule/executor_parallel.rs:211:62 
    |                                                                                                                         
211 |                         .unwrap_or_else(|error| unreachable!(error));                                                   
    |                                                              ^^^^^                                                      
    |                                                                                                                         
help: you might be missing a string literal to format with                                                                    
    |                                                                                                                         
211 |                         .unwrap_or_else(|error| unreachable!("{}", error));                                             
    |                                                              +++++                                                      
                                                                                                                              
error: format argument must be a string literal                                                                               
   --> /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/bevy_ecs-0.6.0/src/schedule/executor_parallel.rs:220:62 
    |                                                                                                                         
220 |                         .unwrap_or_else(|error| unreachable!(error));                                                   
    |                                                              ^^^^^                                                      
    |                                                                                                                         
help: you might be missing a string literal to format with                                                                    
    |                                                                                                                         
220 |                         .unwrap_or_else(|error| unreachable!("{}", error));                                             
    |                                                              +++++                                                      
                                                                                                                              
error: format argument must be a string literal                                                                               
   --> /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/bevy_ecs-0.6.0/src/schedule/executor_parallel.rs:271:58 
    |                                                                                                                         
271 |                     .unwrap_or_else(|error| unreachable!(error));                                                       
    |                                                          ^^^^^                                                          
    |                                                                                                                         
help: you might be missing a string literal to format with                                                                    
    |                                                                                                                         
271 |                     .unwrap_or_else(|error| unreachable!("{}", error));                                                 
    |                                                          +++++                                                          
                                                                                                                              
error: could not compile `bevy_ecs` due to 4 previous errors                                                                  
warning: build failed, waiting for other jobs to finish...                                                                    
^C  Building [=====================>   ] 258/286: gltf-json, ldtk_rust, wgpu-core                                             
```
