### PR TITLE
Take into account spacing when computing atlas size

### DIFF
--- a/src/render/texture_array_cache.rs
+++ b/src/render/texture_array_cache.rs
@@ -138,8 +138,10 @@ impl TextureArrayCache {
 
             let (tile_size, atlas_size, spacing, _) = self.sizes.get(&item).unwrap();
             let array_gpu_image = self.textures.get(&item).unwrap();
-            let tile_count_x = (atlas_size.0 as f32 / tile_size.0).floor();
-            let tile_count_y = (atlas_size.1 as f32 / tile_size.1).floor();
+            let tile_count_x =
+                ((atlas_size.0 as f32 + spacing.x) / (tile_size.0 + spacing.x)).floor();
+            let tile_count_y =
+                ((atlas_size.1 as f32 + spacing.y) / (tile_size.1 + spacing.y)).floor();
             let count = (tile_count_x * tile_count_y) as u32;
 
             let mut command_encoder =


### PR DESCRIPTION
The computation of tile counts previously assumed that `texture_width = tile_count_x * tile_width`. This doesn't work for tile sheets with spacing. This PR makes the computation robust to spacing. It adds the spacing to the atlas width/height (effectively padding the last row/column) and then divides by the tile width/height *plus* the relevant padding.

This fixes the inability to load large tile sheets with padding. For example, a 20x20-tile image with 1x1 padding would crash with a wgpu OOB error, because the padding of every 16 tiles would count as an additional tile. To replicate this, you can modify `examples/atlas_spacing.rs` to use `roguelikeSheet_transparent.png` from [Kenney's Roguelike/RPG pack](https://www.kenney.nl/assets/roguelike-rpg-pack).