### PR TITLE
Impl PartialEq and PartialOrd on TilePos

### DIFF
--- a/src/tiles/mod.rs
+++ b/src/tiles/mod.rs
@@ -9,7 +9,7 @@ pub use storage::*;
 use crate::map::TilemapId;
 
 /// A tile position in the tilemap grid.
-#[derive(Component, Default, Clone, Copy, Debug, Hash, PartialEq, PartialOrd)]
+#[derive(Component, Default, Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd)]
 pub struct TilePos {
     pub x: u32,
     pub y: u32,

--- a/src/tiles/mod.rs
+++ b/src/tiles/mod.rs
@@ -9,7 +9,7 @@ pub use storage::*;
 use crate::map::TilemapId;
 
 /// A tile position in the tilemap grid.
-#[derive(Component, Default, Clone, Copy, Debug, Hash)]
+#[derive(Component, Default, Clone, Copy, Debug, Hash, PartialEq, PartialOrd)]
 pub struct TilePos {
     pub x: u32,
     pub y: u32,


### PR DESCRIPTION
Adding PartialEq and PartialOrd as derives on TilePos because it's pretty common to want to do a bunch of operations on TilePos

PartialEq certainly at least, could take of leave PartialOrd as the default lexicographic ordering might not make sense
(i.e. that TilePos{x:2, y:0} > TilePos {x:1, y:100})