### PR TITLE
Fix grid size: scale tile position by grid_size first, then, then add tile_size to get the corners

### DIFF
--- a/examples/hexagon_column.rs
+++ b/examples/hexagon_column.rs
@@ -50,11 +50,12 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     let tile_size = TilemapTileSize { x: 17.0, y: 15.0 };
+    let grid_size = TilemapGridSize { x: 17.0, y: 15.0 };
 
     commands
         .entity(tilemap_entity)
         .insert_bundle(TilemapBundle {
-            grid_size: tile_size.into(),
+            grid_size,
             size: tilemap_size,
             storage: tile_storage,
             texture: TilemapTexture(texture_handle),

--- a/examples/hexagon_row.rs
+++ b/examples/hexagon_row.rs
@@ -49,11 +49,12 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     let tile_size = TilemapTileSize { x: 15.0, y: 17.0 };
+    let grid_size = TilemapGridSize { x: 15.0, y: 17.0 };
 
     commands
         .entity(tilemap_entity)
         .insert_bundle(TilemapBundle {
-            grid_size: tile_size.into(),
+            grid_size,
             size: tilemap_size,
             storage: tile_storage,
             texture: TilemapTexture(texture_handle),

--- a/src/render/shaders/column_even_hex.wgsl
+++ b/src/render/shaders/column_even_hex.wgsl
@@ -5,19 +5,8 @@ struct Output {
 
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
     var out: Output;
-    var position = vertex_position.xy;
 
-    var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
-        vec2<f32>(position.x, position.y),
-        vec2<f32>(position.x, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y)
-    );
-
-    position = positions[v_index % 4u];
-
-    var position = position * tilemap_data.tile_size;
-
+    var position = vertex_position.xy * tilemap_data.grid_size;
     var offset = floor(0.25 * tilemap_data.grid_size.y);
     if (u32(vertex_position.x) % 2u == 0u) {
         position.y = position.y - offset;
@@ -25,6 +14,14 @@ fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
         position.y = position.y + offset;
     }
     position.x = position.x - vertex_position.x * ceil(0.25 * tilemap_data.grid_size.x);
+
+    var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
+        vec2<f32>(position.x, position.y),
+        vec2<f32>(position.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.y, position.y)
+    );
+    position = positions[v_index % 4u];
 
     out.world_position = mesh.model * vec4<f32>(position, 0.0, 1.0);
 

--- a/src/render/shaders/column_hex.wgsl
+++ b/src/render/shaders/column_hex.wgsl
@@ -5,21 +5,20 @@ struct Output {
 
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
     var out: Output;
-    var position = vertex_position.xy;
+
+    var offset = vec2<f32>(
+        vertex_position.x * floor(-0.25 * tilemap_data.grid_size.x),
+        ceil(0.5 * tilemap_data.grid_size.y)
+    );
+    var position = vertex_position.xy * tilemap_data.grid_size + offset;
 
     var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
         vec2<f32>(position.x, position.y),
-        vec2<f32>(position.x, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y)
+        vec2<f32>(position.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.y, position.y)
     );
-
     position = positions[v_index % 4u];
-
-    var position = position * tilemap_data.tile_size;
-
-    position.x = position.x + vertex_position.x * floor(-0.25 * tilemap_data.grid_size.x);
-    position.y = position.y + vertex_position.x * ceil(0.5 * tilemap_data.grid_size.y);
 
     out.world_position = mesh.model * vec4<f32>(position, 0.0, 1.0);
 

--- a/src/render/shaders/column_hex.wgsl
+++ b/src/render/shaders/column_hex.wgsl
@@ -8,7 +8,7 @@ fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
 
     var offset = vec2<f32>(
         vertex_position.x * floor(-0.25 * tilemap_data.grid_size.x),
-        ceil(0.5 * tilemap_data.grid_size.y)
+        vertex_position.x * ceil(0.5 * tilemap_data.grid_size.y)
     );
     var position = vertex_position.xy * tilemap_data.grid_size + offset;
 

--- a/src/render/shaders/column_odd_hex.wgsl
+++ b/src/render/shaders/column_odd_hex.wgsl
@@ -5,19 +5,8 @@ struct Output {
 
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
     var out: Output;
-    var position = vertex_position.xy;
 
-    var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
-        vec2<f32>(position.x, position.y),
-        vec2<f32>(position.x, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y)
-    );
-
-    position = positions[v_index % 4u];
-
-    var position = position * tilemap_data.tile_size;
-
+    var position = vertex_position.xy * tilemap_data.grid_size;
     var offset = floor(0.25 * tilemap_data.grid_size.y);
     if (u32(vertex_position.x) % 2u == 0u) {
         position.y = position.y + offset;
@@ -25,6 +14,14 @@ fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
         position.y = position.y - offset;
     }
     position.x = position.x - vertex_position.x * ceil(0.25 * tilemap_data.grid_size.x);
+
+    var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
+        vec2<f32>(position.x, position.y),
+        vec2<f32>(position.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.y, position.y)
+    );
+    position = positions[v_index % 4u];
 
     out.world_position = mesh.model * vec4<f32>(position, 0.0, 1.0);
 

--- a/src/render/shaders/row_even_hex.wgsl
+++ b/src/render/shaders/row_even_hex.wgsl
@@ -5,19 +5,8 @@ struct Output {
 
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
     var out: Output;
-    var position = vertex_position.xy;
 
-    var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
-        vec2<f32>(position.x, position.y),
-        vec2<f32>(position.x, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y)
-    );
-
-    position = positions[v_index % 4u];
-
-    var position = position * tilemap_data.tile_size;
-
+    var position = vertex_position.xy * tilemap_data.grid_size;
     var offset = floor(0.25 * tilemap_data.grid_size.x);
     if (u32(vertex_position.y) % 2u == 0u) {
         position.x = position.x - offset;
@@ -25,6 +14,14 @@ fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
         position.x = position.x + offset;
     }
     position.y = position.y - vertex_position.y * ceil(0.25 * tilemap_data.grid_size.y);
+
+    var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
+        vec2<f32>(position.x, position.y),
+        vec2<f32>(position.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.y, position.y)
+    );
+    position = positions[v_index % 4u];
 
     out.world_position = mesh.model * vec4<f32>(position, 0.0, 1.0);
 

--- a/src/render/shaders/row_hex.wgsl
+++ b/src/render/shaders/row_hex.wgsl
@@ -5,21 +5,20 @@ struct Output {
 
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
     var out: Output;
-    var position = vertex_position.xy;
+
+    var offset = vec2<f32>(
+        vertex_position.y * floor(0.5 * tilemap_data.grid_size.x),
+        -1.0 * vertex_position.y * ceil(0.25 * tilemap_data.grid_size.y)
+    );
+    var position = vertex_position.xy * tilemap_data.grid_size + offset;
 
     var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
         vec2<f32>(position.x, position.y),
-        vec2<f32>(position.x, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y)
+        vec2<f32>(position.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.y, position.y)
     );
-
     position = positions[v_index % 4u];
-
-    var position = position * tilemap_data.tile_size;
-
-    position.x = position.x + vertex_position.y * floor(0.5 * tilemap_data.grid_size.x);
-    position.y = position.y - vertex_position.y * ceil(0.25 * tilemap_data.grid_size.y);
 
     out.world_position = mesh.model * vec4<f32>(position, 0.0, 1.0);
 

--- a/src/render/shaders/row_odd_hex.wgsl
+++ b/src/render/shaders/row_odd_hex.wgsl
@@ -7,17 +7,7 @@ fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
     var out: Output;
     var position = vertex_position.xy;
 
-    var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
-        vec2<f32>(position.x, position.y),
-        vec2<f32>(position.x, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y)
-    );
-
-    position = positions[v_index % 4u];
-
-    var position = position * tilemap_data.tile_size;
-
+    var position = vertex_position.xy * tilemap_data.grid_size;
     var offset = floor(0.25 * tilemap_data.grid_size.x);
     if (u32(vertex_position.y) % 2u == 0u) {
         position.x = position.x + offset;
@@ -25,6 +15,14 @@ fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
         position.x = position.x - offset;
     }
     position.y = position.y - vertex_position.y * ceil(0.25 * tilemap_data.grid_size.y);
+
+    var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
+        vec2<f32>(position.x, position.y),
+        vec2<f32>(position.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.y, position.y)
+    );
+    position = positions[v_index % 4u];
 
     out.world_position = mesh.model * vec4<f32>(position, 0.0, 1.0);
 

--- a/src/render/shaders/staggered_iso.wgsl
+++ b/src/render/shaders/staggered_iso.wgsl
@@ -11,18 +11,8 @@ fn project_iso(pos: vec2<f32>, tile_width: f32, tile_height: f32) -> vec2<f32> {
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
     var out: Output;
     var world_pos = mesh.model * vec4<f32>(vertex_position.xy, 0.0, 1.0);
-    var position = vertex_position.xy;
+    var position = vertex_position.xy * tilemap_data.grid_size;
     var world_translation = mesh.model * vec4<f32>(0.0, 0.0, 0.0, 1.0);
-
-    var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
-        vec2<f32>(position.x, position.y),
-        vec2<f32>(position.x, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y)
-    );
-
-    position = positions[v_index % 4u];
-    position = position * tilemap_data.tile_size;
 
     var offset = floor(0.25 * tilemap_data.grid_size.x);
     if (u32(world_pos.y) % 2u == 0u) {
@@ -32,6 +22,14 @@ fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
     }
     position.y = position.y - (world_pos.y * (tilemap_data.grid_size.y / 2.0));
     position.x = position.x + world_translation.x;
+
+    var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
+        vec2<f32>(position.x, position.y),
+        vec2<f32>(position.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.y, position.y)
+    );
+    position = positions[v_index % 4u];
 
     out.world_position = vec4<f32>(position.xy, world_pos.zw);
 


### PR DESCRIPTION
Currently, the `fix-grid-size` branch scales tile positions by `tile_size`, but this does not place the tiles at `grid_size` multiples (rather it places them at `tile_size` multiples). So, first we should scale by `grid_size`, and then add rectangular `tile_size`d offsets to get the corner positions. 