### PR TITLE
Square tile shader must also take into account `grid_size` and `tile_size` separately

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -39,11 +39,12 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     }
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
+    let grid_size = TilemapGridSize { x: 16.0, y: 16.0 };
 
     commands
         .entity(tilemap_entity)
         .insert_bundle(TilemapBundle {
-            grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
+            grid_size,
             size: tilemap_size,
             storage: tile_storage,
             texture: TilemapTexture(texture_handle),

--- a/src/render/shaders/square.wgsl
+++ b/src/render/shaders/square.wgsl
@@ -5,18 +5,16 @@ struct Output {
 
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> Output {
     var out: Output;
-    var position = vertex_position.xy;
 
+    var position = vertex_position.xy * tilemap_data.grid_size;
     var positions: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
         vec2<f32>(position.x, position.y),
-        vec2<f32>(position.x, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y + 1.0),
-        vec2<f32>(position.x + 1.0, position.y)
+        vec2<f32>(position.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.x, position.y + tilemap_data.tile_size.y),
+        vec2<f32>(position.x + tilemap_data.tile_size.x, position.y)
     );
 
     position = positions[v_index % 4u];
-
-    var position = position * tilemap_data.tile_size;
     out.world_position = mesh.model * vec4<f32>(position, 0.0, 1.0);
 
     return out;


### PR DESCRIPTION
We updated hexagonal to use `grid_size` and `tile_size` separately, but left square tiles as is. This update fixes that.

Fixes issue #204 