### PR TITLE
Add TilemapRenderSettings Resource to set Custom Chunk Size

### DIFF
--- a/examples/chunk_size.rs
+++ b/examples/chunk_size.rs
@@ -1,0 +1,118 @@
+use bevy::{
+    prelude::*, 
+    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    render::texture::ImageSettings, window::PresentMode
+};
+
+use bevy_ecs_tilemap::prelude::*;
+mod helpers;
+
+fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn_bundle(Camera2dBundle::default());
+
+    let texture_handle: Handle<Image> = asset_server.load("tiles.png");
+
+    let tilemap_size = TilemapSize { x: 128, y: 128 };
+
+    // Create a tilemap entity a little early.
+    // We want this entity early because we need to tell each tile which tilemap entity
+    // it is associated with. This is done with the TilemapId component on each tile.
+    // Eventually, we will insert the `TilemapBundle` bundle on the entity, which
+    // will contain various necessary components, such as `TileStorage`.
+    let tilemap_entity = commands.spawn().id();
+
+    // To begin creating the map we will need a `TileStorage` component.
+    // This component is a grid of tile entities and is used to help keep track of individual
+    // tiles in the world. If you have multiple layers of tiles you would have a tilemap entity
+    // per layer, each with their own `TileStorage` component.
+    let mut tile_storage = TileStorage::empty(tilemap_size);
+
+    // Spawn the elements of the tilemap.
+    for x in 0..tilemap_size.x {
+        for y in 0..tilemap_size.y {
+            let tile_pos = TilePos { x, y };
+            let tile_entity = commands
+                .spawn()
+                .insert_bundle(TileBundle {
+                    position: tile_pos,
+                    tilemap_id: TilemapId(tilemap_entity),
+                    ..Default::default()
+                })
+                .id();
+
+            commands.entity(tilemap_entity).add_child(tile_entity);
+            tile_storage.set(&tile_pos, Some(tile_entity));
+        }
+    }
+
+    let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
+
+    commands
+        .entity(tilemap_entity)
+        .insert_bundle(TilemapBundle {
+            grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
+            size: tilemap_size,
+            storage: tile_storage,
+            texture: TilemapTexture(texture_handle),
+            tile_size,
+            transform: bevy_ecs_tilemap::helpers::get_centered_transform_2d(
+                &tilemap_size,
+                &tile_size,
+                0.0,
+            ),
+            ..Default::default()
+        });
+}
+
+fn swap_texture_or_hide(
+    asset_server: Res<AssetServer>,
+    keyboard_input: Res<Input<KeyCode>>,
+    mut query: Query<(&mut TilemapTexture, &mut Visibility)>,
+) {
+    if keyboard_input.just_pressed(KeyCode::Space) {
+        let texture_handle_a: Handle<Image> = asset_server.load("tiles.png");
+        let texture_handle_b: Handle<Image> = asset_server.load("tiles2.png");
+        for (mut tilemap_tex, _) in &mut query {
+            if &tilemap_tex.0 == &texture_handle_a {
+                tilemap_tex.0 = texture_handle_b.clone();
+            } else {
+                tilemap_tex.0 = texture_handle_a.clone();
+            }
+        }
+    }
+    if keyboard_input.just_pressed(KeyCode::H) {
+        for (_, mut visibility) in &mut query {
+            if visibility.is_visible {
+                visibility.is_visible = false;
+            } else {
+                visibility.is_visible = true;
+            }
+        }
+    }
+}
+
+fn main() {
+    App::new()
+        .insert_resource(WindowDescriptor {
+            width: 1270.0,
+            height: 720.0,
+            title: String::from(
+                "Custom Chunk Size Example - Press Space to change Texture and H to show/hide tilemap.",
+            ),
+            ..Default::default()
+        })
+        // Thie example demonstrates configuring the Tilemap rendering pipeline to use a smaller
+        // chunk size per mesh. It must be added before the `TilemapPlugin`.
+        .insert_resource(TilemapRenderSettings {
+            chunk_size: UVec2::new(32, 32),
+        })
+        .insert_resource(ImageSettings::default_nearest())
+        .add_plugins(DefaultPlugins)
+        .add_plugin(LogDiagnosticsPlugin::default())
+        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(TilemapPlugin)
+        .add_startup_system(startup)
+        .add_system(helpers::camera::movement)
+        .add_system(swap_texture_or_hide)
+        .run();
+}

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -3,7 +3,7 @@ use bevy::{
     prelude::{Component, Entity, Handle, Image},
 };
 
-/// Describes the information needed for creating a window.
+/// Provides a way to set custom Tilemap render pipeline parameters. 
 ///
 /// This should be set up before adding the [`TilemapPlugin`](crate::TilemapPlugin).
 ///

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -3,6 +3,18 @@ use bevy::{
     prelude::{Component, Entity, Handle, Image},
 };
 
+/// Describes the information needed for creating a window.
+///
+/// This should be set up before adding the [`TilemapPlugin`](crate::TilemapPlugin).
+///
+/// See [`examples/chunk_size.rs`] for usage in the main fn. 
+#[derive(Debug, Default, Copy, Clone)]
+pub struct TilemapRenderSettings {
+    /// The `chunk_size` is set to the total tile dimensions per chunk, a grouping of 
+    /// tiles combined and rendered as a single mesh by the Tilemap render pipeline.
+    pub chunk_size: UVec2,
+}
+
 /// A component which stores a reference to the tilemap entity.
 #[derive(Component, Clone, Copy, Debug, Hash)]
 pub struct TilemapId(pub Entity);

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use bevy::{
-    math::{Mat4, UVec2, UVec4, Vec3Swizzles},
+    math::{Mat4, UVec4, Vec3Swizzles},
     prelude::{
         Commands, Component, ComputedVisibility, Entity, GlobalTransform, Query, Res, ResMut,
         Transform, Vec2,
@@ -18,21 +18,9 @@ use crate::{
         TilemapId, TilemapSize, TilemapSpacing, TilemapTexture, TilemapTextureSize,
         TilemapTileSize, TilemapType,
     },
-    tiles::TilePos,
 };
-use crate::{prelude::TilemapGridSize, render::SecondsSinceStartup};
+use crate::{prelude::TilemapGridSize, render::SecondsSinceStartup, render::ChunkCoordinates};
 
-pub const CHUNK_SIZE_2D: UVec2 = UVec2::from_array([64, 64]);
-
-fn map_tile_to_chunk(tile_position: &TilePos) -> UVec2 {
-    let tile_pos: UVec2 = tile_position.into();
-    tile_pos / CHUNK_SIZE_2D
-}
-
-pub(crate) fn map_tile_to_chunk_tile(tile_position: &TilePos, chunk_position: &UVec2) -> UVec2 {
-    let tile_pos: UVec2 = tile_position.into();
-    tile_pos - (*chunk_position * CHUNK_SIZE_2D)
-}
 
 use super::{
     chunk::{ChunkId, PackedTileData, RenderChunk2dStorage, TilemapUniformData},
@@ -50,6 +38,7 @@ pub(crate) fn prepare(
     mut chunk_storage: ResMut<RenderChunk2dStorage>,
     mut mesh_uniforms: ResMut<DynamicUniformBuffer<MeshUniform>>,
     mut tilemap_uniforms: ResMut<DynamicUniformBuffer<TilemapUniformData>>,
+    chunk_coordinates: Res<ChunkCoordinates>,
     extracted_tiles: Query<&ExtractedTile>,
     extracted_tilemaps: Query<(
         Entity,
@@ -69,7 +58,7 @@ pub(crate) fn prepare(
     seconds_since_startup: Res<SecondsSinceStartup>,
 ) {
     for tile in extracted_tiles.iter() {
-        let chunk_pos = map_tile_to_chunk(&tile.position);
+        let chunk_pos = chunk_coordinates.map_tile_to_chunk(&tile.position);
         let (
             _entity,
             transform,
@@ -92,12 +81,12 @@ pub(crate) fn prepare(
             tile.tilemap_id.0.id(),
         );
 
-        let relative_tile_pos = map_tile_to_chunk_tile(&tile.position, &chunk_pos).into();
+        let relative_tile_pos = chunk_coordinates.map_tile_to_chunk_tile(&tile.position, &chunk_pos).into();
         let chunk = chunk_storage.get_or_add(
             tile.entity,
             relative_tile_pos,
             &chunk_data,
-            CHUNK_SIZE_2D,
+            chunk_coordinates.chunk_size(),
             *mesh_type,
             (*tile_size).into(),
             (*texture_size).into(),
@@ -111,7 +100,7 @@ pub(crate) fn prepare(
         chunk.set(
             &relative_tile_pos.into(),
             Some(PackedTileData {
-                position: map_tile_to_chunk_tile(&tile.position, &chunk_pos)
+                position: chunk_coordinates.map_tile_to_chunk_tile(&tile.position, &chunk_pos)
                     .as_vec2()
                     .extend(tile.tile.position.z)
                     .extend(tile.tile.position.w),


### PR DESCRIPTION
This change came from some testing I was doing in my game with different chunk sizes. It seemed reasonable that for larger tile sizes, it may be preferable to reduce the chunk size. It _seemed_ to yield slightly better performance compared to the default 64x64 in my case (I didn't use any rigorous benching to verify this, just basic FPS observations). 

I'm not sure if this is something that would be useful, but I figured I'd clean up my test code and offer up the PR just in case. Of course, no worries if it's an undesirable change -- feel free to ignore. :)

---- 

This change adds a resource that could contain "custom parameters" (currently just `chunk_size: UVec2`) into the render pipeline. Similar to `WindowDescriptor` has to be added before the `DefaultPlugins` are added for bevy, this resource must also be added prior to the `TilemapPlugin` being added. 

For example: 
```rust
fn main() {
    App::new()
        .insert_resource(WindowDescriptor {
            width: 1270.0,
            height: 720.0,
            title: String::from(
                "Custom Chunk Size Example - Press Space to change Texture and H to show/hide tilemap.",
            ),
            ..Default::default()
        })
        // Thie example demonstrates configuring the Tilemap rendering pipeline to use a smaller
        // chunk size per mesh. It must be added before the `TilemapPlugin`.
        .insert_resource(TilemapRenderSettings {
            chunk_size: UVec2::new(32, 32),
        })
        .insert_resource(ImageSettings::default_nearest())
        .add_plugins(DefaultPlugins)
        .add_plugin(LogDiagnosticsPlugin::default())
        .add_plugin(FrameTimeDiagnosticsPlugin::default())
        .add_plugin(TilemapPlugin)
        .add_startup_system(startup)
        .add_system(helpers::camera::movement)
        .add_system(swap_texture_or_hide)
        .run();
}
```

