### PR TITLE
Update Cargo.toml so that bevy_winit compile does not fail on unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,21 @@ regex = "1.5.4"
 
 [dev-dependencies]
 anyhow = { version = "1.0" }
-bevy = { version = "0.8", default-features = false, features=["bevy_core_pipeline", "bevy_render", "bevy_asset"]}
 ldtk_rust = { version = "0.6" }
 rand = "0.8"
 env_logger = "0.9"
 serde_json = { version = "1.0" }
 tiled = { version = "0.9", default-features = false }
+
+[dev-dependencies.bevy]
+version = "0.8"
+default-features = false
+features=["bevy_core_pipeline", "bevy_render", "bevy_asset", "png", "bevy_winit"]
+
+[target.'cfg(unix)'.dev-dependencies.bevy]
+version = "0.8"
+default-features = false
+features=["bevy_core_pipeline", "bevy_render", "bevy_asset", "png", "bevy_winit", "x11"]
 
 [target.wasm32-unknown-unknown]
 runner = "wasm-server-runner"


### PR DESCRIPTION
We need to select one of `x11` or `wayland`.