### PR TITLE
Don't use bevy_render feature which includes a bunch of 3d stuff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ atlas = []
 render = []
 
 [dependencies]
-bevy = { version = "0.8", default-features = false, features=["bevy_core_pipeline", "bevy_render", "bevy_asset"] }
+bevy = { version = "0.8", default-features = false, features=["bevy_core_pipeline", "bevy_asset"] }
 log = "0.4"
 regex = "1.5.4"
 


### PR DESCRIPTION
Noticed my game preparing skinned meshes and lights and stuff and tracked it down here.

I don't think there's anything in `bevy_render` actually required here, except for `bevy_core_pipeline` which is already being included.