### PR TITLE
correct entity comparisons when determining chunk visibility

### DIFF
--- a/src/render/queue.rs
+++ b/src/render/queue.rs
@@ -136,7 +136,11 @@ pub fn queue_meshes(
                 .unwrap();
 
             for (entity, chunk_id, transform, tilemap_id) in standard_tilemap_meshes.iter() {
-                if !visible_entities.entities.contains(&tilemap_id.0) {
+                if !visible_entities
+                    .entities
+                    .iter()
+                    .any(|&entity| entity.id() == tilemap_id.0.id())
+                {
                     continue;
                 }
 


### PR DESCRIPTION
Resolves #259

`contains` does not compare entities as expected. we can just compare the entity ids directly