### PR TITLE
Tilemap centering transform functions should be based on grid size, not tile size, and some small clippy lints.

### DIFF
--- a/examples/accessing_tiles.rs
+++ b/examples/accessing_tiles.rs
@@ -77,19 +77,20 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // This is the size of each individual tiles in pixels.
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
+    let grid_size = tile_size.into();
 
     // Spawns a tilemap.
     // Once the tile storage is inserted onto the tilemap entity it can no longer be accessed.
     commands
         .entity(tilemap_entity)
         .insert_bundle(TilemapBundle {
-            grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
+            grid_size,
             size: tilemap_size,
             storage: tile_storage,
             map_type: tilemap_type,
             texture: TilemapTexture(texture_handle),
             tile_size,
-            transform: get_tilemap_center_transform(&tilemap_size, &tile_size, 0.0),
+            transform: get_tilemap_center_transform(&tilemap_size, &grid_size, 0.0),
             ..Default::default()
         })
         .insert(LastUpdate(0.0))

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -17,16 +17,16 @@ struct TilemapMetadata {
     grid_size: TilemapGridSize,
 }
 
-const BACKGROUND: &'static str = "tiles.png";
+const BACKGROUND: &str = "tiles.png";
 const BACKGROUND_METADATA: TilemapMetadata = TilemapMetadata {
     size: TilemapSize { x: 20, y: 20 },
     tile_size: TilemapTileSize { x: 16.0, y: 16.0 },
     grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
 };
 
-const FLOWERS: &'static str = "flower_sheet.png";
+const FLOWERS: &str = "flower_sheet.png";
 const FLOWERS_METADATA: TilemapMetadata = TilemapMetadata {
-    size: TilemapSize { x: 10, y: 10 },
+    size: TilemapSize { x: 20, y: 20 },
     tile_size: TilemapTileSize { x: 32.0, y: 32.0 },
     grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
 };
@@ -42,23 +42,15 @@ fn create_background(mut commands: Commands, asset_server: Res<AssetServer>) {
         tile_size,
     } = BACKGROUND_METADATA;
 
-    let mut tilemap_storage = TileStorage::empty(size);
+    let mut tile_storage = TileStorage::empty(size);
 
-    for x in 0..size.x {
-        for y in 0..size.y {
-            let tile_pos = TilePos { x, y };
-            let tile_entity = commands
-                .spawn()
-                .insert_bundle(TileBundle {
-                    position: tile_pos,
-                    tilemap_id: TilemapId(tilemap_entity),
-                    ..Default::default()
-                })
-                .id();
-            // Here we let the tile storage component know what tiles we have.
-            tilemap_storage.set(&tile_pos, Some(tile_entity));
-        }
-    }
+    fill_tilemap(
+        TileTexture(0),
+        size,
+        TilemapId(tilemap_entity),
+        &mut commands,
+        &mut tile_storage,
+    );
 
     commands
         .entity(tilemap_entity)
@@ -66,9 +58,9 @@ fn create_background(mut commands: Commands, asset_server: Res<AssetServer>) {
             size,
             grid_size,
             tile_size,
-            storage: tilemap_storage,
-            texture: TilemapTexture(texture_handle.clone()),
-            transform: get_tilemap_center_transform(&size, &tile_size, 0.0),
+            storage: tile_storage,
+            texture: TilemapTexture(texture_handle),
+            transform: get_tilemap_center_transform(&size, &grid_size, 0.0),
             ..Default::default()
         });
 }
@@ -82,7 +74,7 @@ fn create_animated_flowers(mut commands: Commands, asset_server: Res<AssetServer
         tile_size,
     } = FLOWERS_METADATA;
 
-    let mut tilemap_storage = TileStorage::empty(size);
+    let mut tile_storage = TileStorage::empty(size);
 
     let tilemap_entity = commands.spawn().id();
 
@@ -105,7 +97,7 @@ fn create_animated_flowers(mut commands: Commands, asset_server: Res<AssetServer
                 ..Default::default()
             })
             .id();
-        tilemap_storage.set(&tile_pos, Some(tile_entity));
+        tile_storage.set(&tile_pos, Some(tile_entity));
         // To enable animation, we must insert the `AnimatedTile` component on
         // each tile that is to be animated.
         commands.entity(tile_entity).insert(AnimatedTile {
@@ -120,10 +112,10 @@ fn create_animated_flowers(mut commands: Commands, asset_server: Res<AssetServer
         .insert_bundle(TilemapBundle {
             grid_size,
             size,
-            storage: tilemap_storage,
-            texture: TilemapTexture(texture_handle.clone()),
+            storage: tile_storage,
+            texture: TilemapTexture(texture_handle),
             tile_size,
-            transform: get_tilemap_center_transform(&size, &tile_size, 1.0),
+            transform: get_tilemap_center_transform(&size, &grid_size, 1.0),
             ..Default::default()
         });
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -45,7 +45,7 @@ fn startup(
     }
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = TilemapGridSize { x: 16.0, y: 16.0 };
+    let grid_size = tile_size.into();
 
     commands
         .entity(tilemap_entity)
@@ -55,7 +55,7 @@ fn startup(
             storage: tile_storage,
             texture: TilemapTexture(texture_handle),
             tile_size,
-            transform: get_tilemap_center_transform(&tilemap_size, &tile_size, 0.0),
+            transform: get_tilemap_center_transform(&tilemap_size, &grid_size, 0.0),
             ..Default::default()
         });
 

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -25,16 +25,17 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
+    let grid_size = tile_size.into();
 
     commands
         .entity(tilemap_entity)
         .insert_bundle(TilemapBundle {
-            grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
+            grid_size,
             size: tilemap_size,
             storage: tile_storage,
             texture: TilemapTexture(texture_handle),
             tile_size,
-            transform: get_tilemap_center_transform(&tilemap_size, &tile_size, 0.0),
+            transform: get_tilemap_center_transform(&tilemap_size, &grid_size, 0.0),
             ..Default::default()
         });
 }

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -79,7 +79,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .entity(tilemap_entity)
         .insert_bundle(TilemapBundle {
-            grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
+            grid_size,
             size: total_size,
             storage: tile_storage,
             texture: TilemapTexture(texture_handle),

--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -31,16 +31,17 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     }
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
+    let grid_size = tile_size.into();
 
     commands
         .entity(tilemap_entity)
         .insert_bundle(TilemapBundle {
-            grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
+            grid_size,
             size: tilemap_size,
             storage: tile_storage,
             texture: TilemapTexture(texture_handle),
             tile_size,
-            transform: get_tilemap_center_transform(&tilemap_size, &tile_size, 0.0),
+            transform: get_tilemap_center_transform(&tilemap_size, &grid_size, 0.0),
             map_type: TilemapType::Square {
                 diagonal_neighbors: true,
             },

--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -241,7 +241,7 @@ pub fn process_loaded_maps(
                             spacing: tile_spacing,
                             transform: get_tilemap_center_transform(
                                 &map_size,
-                                &tile_size,
+                                &grid_size,
                                 layer.layer_index as f32,
                             ) * Transform::from_xyz(offset_x, -offset_y, 0.0),
                             map_type: mesh_type,

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -22,16 +22,17 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
+    let grid_size = tile_size.into();
 
     commands
         .entity(tilemap_entity)
         .insert_bundle(TilemapBundle {
-            grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
+            grid_size,
             size: tilemap_size,
             storage: tile_storage,
             texture: TilemapTexture(texture_handle.clone()),
             tile_size,
-            transform: get_tilemap_center_transform(&tilemap_size, &tile_size, 0.0),
+            transform: get_tilemap_center_transform(&tilemap_size, &grid_size, 0.0),
             ..Default::default()
         });
 
@@ -50,12 +51,12 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .entity(tilemap_entity)
         .insert_bundle(TilemapBundle {
-            grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
+            grid_size: grid_size,
             size: tilemap_size,
             storage: tile_storage,
             texture: TilemapTexture(texture_handle),
             tile_size: TilemapTileSize { x: 16.0, y: 16.0 },
-            transform: get_tilemap_center_transform(&tilemap_size, &tile_size, 1.0)
+            transform: get_tilemap_center_transform(&tilemap_size, &grid_size, 1.0)
                 * Transform::from_xyz(32.0, 32.0, 0.0),
             ..Default::default()
         });

--- a/examples/ldtk/ldtk.rs
+++ b/examples/ldtk/ldtk.rs
@@ -1,6 +1,6 @@
 use bevy_ecs_tilemap::{
     helpers::geometry::get_tilemap_center_transform,
-    map::{TilemapGridSize, TilemapId, TilemapSize, TilemapTexture, TilemapTileSize},
+    map::{TilemapId, TilemapSize, TilemapTexture, TilemapTileSize},
     tiles::{TileBundle, TilePos, TileStorage, TileTexture},
     TilemapBundle,
 };
@@ -58,14 +58,12 @@ impl AssetLoader for LdtkLoader {
                 .tilesets
                 .iter()
                 .filter_map(|tileset| {
-                    if let Some(rel_path) = &tileset.rel_path {
-                        Some((
+                    tileset.rel_path.as_ref().map(|rel_path| {
+                        (
                             tileset.uid,
                             load_context.path().parent().unwrap().join(rel_path).into(),
-                        ))
-                    } else {
-                        None
-                    }
+                        )
+                    })
                 })
                 .collect();
 
@@ -202,16 +200,18 @@ pub fn process_loaded_tile_maps(
                             storage.set(&position, Some(tile_entity));
                         }
 
+                        let grid_size = tile_size.into();
+
                         // Create the tilemap
                         commands.entity(map_entity).insert_bundle(TilemapBundle {
-                            grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
+                            grid_size,
                             size,
                             storage,
                             texture: TilemapTexture(texture),
                             tile_size,
                             transform: get_tilemap_center_transform(
                                 &size,
-                                &tile_size,
+                                &grid_size,
                                 layer_id as f32,
                             ),
                             ..default()

--- a/examples/move_tile.rs
+++ b/examples/move_tile.rs
@@ -26,8 +26,9 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         })
         .id();
     tile_storage.set(&tile_pos, Some(tile_entity));
+
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = TilemapGridSize { x: 16.0, y: 16.0 };
+    let grid_size = tile_size.into();
 
     commands
         .entity(tilemap_entity)
@@ -37,7 +38,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
             storage: tile_storage,
             texture: TilemapTexture(texture_handle),
             tile_size,
-            transform: get_tilemap_center_transform(&tilemap_size, &tile_size, 0.0),
+            transform: get_tilemap_center_transform(&tilemap_size, &grid_size, 0.0),
             ..Default::default()
         });
 }

--- a/examples/random_map.rs
+++ b/examples/random_map.rs
@@ -34,16 +34,17 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     }
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
+    let grid_size = tile_size.into();
 
     commands
         .entity(tilemap_entity)
         .insert_bundle(TilemapBundle {
-            grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
+            grid_size,
             size: tilemap_size,
             storage: tile_storage,
             texture: TilemapTexture(texture_handle),
             tile_size,
-            transform: get_tilemap_center_transform(&tilemap_size, &tile_size, 0.0),
+            transform: get_tilemap_center_transform(&tilemap_size, &grid_size, 0.0),
             ..Default::default()
         });
 }

--- a/examples/remove_tiles.rs
+++ b/examples/remove_tiles.rs
@@ -29,16 +29,17 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     }
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
+    let grid_size = tile_size.into();
 
     commands
         .entity(tilemap_entity)
         .insert_bundle(TilemapBundle {
-            grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
+            grid_size,
             size: tilemap_size,
             storage: tile_storage,
             texture: TilemapTexture(texture_handle),
             tile_size,
-            transform: get_tilemap_center_transform(&tilemap_size, &tile_size, 0.0),
+            transform: get_tilemap_center_transform(&tilemap_size, &grid_size, 0.0),
             ..Default::default()
         })
         .insert(LastUpdate::default());

--- a/examples/visibility.rs
+++ b/examples/visibility.rs
@@ -29,16 +29,17 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     }
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
+    let grid_size = tile_size.into();
 
     commands
         .entity(tilemap_entity)
         .insert_bundle(TilemapBundle {
-            grid_size: TilemapGridSize { x: 16.0, y: 16.0 },
+            grid_size,
             size: tilemap_size,
             storage: tile_storage,
             texture: TilemapTexture(texture_handle),
             tile_size,
-            transform: get_tilemap_center_transform(&tilemap_size, &tile_size, 0.0),
+            transform: get_tilemap_center_transform(&tilemap_size, &grid_size, 0.0),
             ..Default::default()
         })
         .insert(LastUpdate::default());

--- a/src/helpers/geometry.rs
+++ b/src/helpers/geometry.rs
@@ -1,12 +1,12 @@
-use crate::{TilemapSize, TilemapTileSize, Transform};
+use crate::{TilemapGridSize, TilemapSize, Transform};
 use bevy::math::Vec2;
 
 /// Calculates a [`Vec2`] position for a tilemap so that when set to this position, it shows up
 /// centered on the screen.
-pub fn get_tilemap_center(size: &TilemapSize, tile_size: &TilemapTileSize) -> Vec2 {
+pub fn get_tilemap_center(size: &TilemapSize, grid_size: &TilemapGridSize) -> Vec2 {
     Vec2::new(
-        -(size.x as f32 * tile_size.x as f32) / 2.0,
-        -(size.y as f32 * tile_size.y as f32) / 2.0,
+        -(size.x as f32 * grid_size.x) / 2.0,
+        -(size.y as f32 * grid_size.y) / 2.0,
     )
 }
 
@@ -14,9 +14,9 @@ pub fn get_tilemap_center(size: &TilemapSize, tile_size: &TilemapTileSize) -> Ve
 /// centered on the screen.
 pub fn get_tilemap_center_transform(
     size: &TilemapSize,
-    tile_size: &TilemapTileSize,
+    grid_size: &TilemapGridSize,
     z: f32,
 ) -> Transform {
-    let center = get_tilemap_center(size, tile_size);
+    let center = get_tilemap_center(size, grid_size);
     Transform::from_xyz(center.x, center.y, z)
 }


### PR DESCRIPTION
Animation example was slightly broken before. Now it works better. 