### PR TITLE
Fix example support for rectangular grids

### DIFF
--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -185,7 +185,7 @@ pub fn process_loaded_maps(
 
                         for x in 0..map_size.x {
                             for y in 0..map_size.y {
-                                let mut mapped_y = x;
+                                let mut mapped_y = y;
                                 if tiled_map.map.orientation == tiled::Orientation::Orthogonal {
                                     mapped_y = (tiled_map.map.height - 1) as u32 - y;
                                 }


### PR DESCRIPTION
See #318 - if `map_size.x > map_size.y` for tiled grids the examples will panic with an out of bounds exception. It seems this is because the `y` value while loading the map is initialised to `map_size.x` instead of `map_size.y`.