### PR TITLE
`TileTexture` Rename for clarity.

### DIFF
--- a/examples/accessing_tiles.rs
+++ b/examples/accessing_tiles.rs
@@ -70,7 +70,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 // We can replace the tile texture component like so:
                 commands
                     .entity(tile_storage.get(&pos).unwrap())
-                    .insert(TileTexture(color));
+                    .insert(TileTextureIndex(color));
             }
         }
     }
@@ -106,7 +106,7 @@ fn update_map(
         &TileStorage,
         &TilemapType,
     )>,
-    mut tile_query: Query<&mut TileTexture>,
+    mut tile_query: Query<&mut TileTextureIndex>,
 ) {
     let current_time = time.seconds_since_startup();
     for (mut current_color, mut last_update, tile_storage, tilemap_type) in tilemap_query.iter_mut()

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -4,7 +4,7 @@ use bevy::{
     render::texture::ImageSettings,
 };
 use bevy_ecs_tilemap::prelude::*;
-use bevy_ecs_tilemap::tiles::{AnimatedTile, TileBundle, TilePos, TileStorage, TileTexture};
+use bevy_ecs_tilemap::tiles::{AnimatedTile, TileBundle, TilePos, TileStorage, TileTextureIndex};
 use bevy_ecs_tilemap::{TilemapBundle, TilemapPlugin};
 use rand::seq::IteratorRandom;
 use rand::thread_rng;
@@ -45,7 +45,7 @@ fn create_background(mut commands: Commands, asset_server: Res<AssetServer>) {
     let mut tile_storage = TileStorage::empty(size);
 
     fill_tilemap(
-        TileTexture(0),
+        TileTextureIndex(0),
         size,
         TilemapId(tilemap_entity),
         &mut commands,
@@ -93,7 +93,7 @@ fn create_animated_flowers(mut commands: Commands, asset_server: Res<AssetServer
             .insert_bundle(TileBundle {
                 position: tile_pos,
                 tilemap_id: TilemapId(tilemap_entity),
-                texture: TileTexture(0),
+                texture_index: TileTextureIndex(0),
                 ..Default::default()
             })
             .id();

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -17,7 +17,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tilemap_entity = commands.spawn().id();
 
     fill_tilemap(
-        TileTexture(0),
+        TileTextureIndex(0),
         tilemap_size,
         TilemapId(tilemap_entity),
         &mut commands,

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -26,7 +26,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tilemap_id = TilemapId(tilemap_entity);
 
     fill_tilemap_rect_color(
-        TileTexture(5),
+        TileTextureIndex(5),
         TilePos { x: 0, y: 0 },
         quadrant_size,
         Color::rgba(1.0, 0.0, 0.0, 1.0),
@@ -36,7 +36,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect_color(
-        TileTexture(5),
+        TileTextureIndex(5),
         TilePos {
             x: QUADRANT_SIDE_LENGTH,
             y: 0,
@@ -49,7 +49,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect_color(
-        TileTexture(5),
+        TileTextureIndex(5),
         TilePos {
             x: 0,
             y: QUADRANT_SIDE_LENGTH,
@@ -62,7 +62,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect_color(
-        TileTexture(5),
+        TileTextureIndex(5),
         TilePos {
             x: QUADRANT_SIDE_LENGTH,
             y: QUADRANT_SIDE_LENGTH,

--- a/examples/frustum_cull_test.rs
+++ b/examples/frustum_cull_test.rs
@@ -69,7 +69,7 @@ fn spawn_tilemap(mut commands: Commands, tile_handle_square: Res<TileHandleSquar
     let tilemap_id = TilemapId(tilemap_entity);
 
     fill_tilemap(
-        TileTexture(0),
+        TileTextureIndex(0),
         total_size,
         tilemap_id,
         &mut commands,

--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -213,7 +213,7 @@ pub fn process_loaded_maps(
                                     .insert_bundle(TileBundle {
                                         position: tile_pos,
                                         tilemap_id: TilemapId(layer_entity),
-                                        texture: TileTexture(tile_id),
+                                        texture_index: TileTextureIndex(tile_id),
                                         flip: TileFlip {
                                             x: map_tile.flip_h,
                                             y: map_tile.flip_v,

--- a/examples/hexagon_column.rs
+++ b/examples/hexagon_column.rs
@@ -26,7 +26,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tilemap_id = TilemapId(tilemap_entity);
 
     fill_tilemap_rect(
-        TileTexture(0),
+        TileTextureIndex(0),
         TilePos { x: 0, y: 0 },
         quadrant_size,
         tilemap_id,
@@ -35,7 +35,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect(
-        TileTexture(1),
+        TileTextureIndex(1),
         TilePos {
             x: QUADRANT_SIDE_LENGTH,
             y: 0,
@@ -47,7 +47,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect(
-        TileTexture(2),
+        TileTextureIndex(2),
         TilePos {
             x: 0,
             y: QUADRANT_SIDE_LENGTH,
@@ -59,7 +59,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect(
-        TileTexture(3),
+        TileTextureIndex(3),
         TilePos {
             x: QUADRANT_SIDE_LENGTH,
             y: QUADRANT_SIDE_LENGTH,

--- a/examples/hexagon_generation.rs
+++ b/examples/hexagon_generation.rs
@@ -55,7 +55,7 @@ fn spawn_tilemap(mut commands: Commands, tile_handle_hex_row: Res<TileHandleHexR
     let hex_coord_system = HexCoordSystem::Row;
 
     fill_tilemap_hexagon(
-        TileTexture(0),
+        TileTextureIndex(0),
         TilePos {
             x: MAP_SIDE_LENGTH / 2,
             y: MAP_SIDE_LENGTH / 2,
@@ -181,7 +181,7 @@ fn swap_map_type(
 
             // Re-generate tiles in a hexagonal pattern.
             fill_tilemap_hexagon(
-                TileTexture(0),
+                TileTextureIndex(0),
                 TilePos {
                     x: MAP_SIDE_LENGTH / 2,
                     y: MAP_SIDE_LENGTH / 2,

--- a/examples/hexagon_row.rs
+++ b/examples/hexagon_row.rs
@@ -25,7 +25,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tilemap_id = TilemapId(tilemap_entity);
 
     fill_tilemap_rect(
-        TileTexture(0),
+        TileTextureIndex(0),
         TilePos { x: 0, y: 0 },
         quadrant_size,
         tilemap_id,
@@ -34,7 +34,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect(
-        TileTexture(1),
+        TileTextureIndex(1),
         TilePos {
             x: QUADRANT_SIDE_LENGTH,
             y: 0,
@@ -46,7 +46,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect(
-        TileTexture(2),
+        TileTextureIndex(2),
         TilePos {
             x: 0,
             y: QUADRANT_SIDE_LENGTH,
@@ -58,7 +58,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect(
-        TileTexture(3),
+        TileTextureIndex(3),
         TilePos {
             x: QUADRANT_SIDE_LENGTH,
             y: QUADRANT_SIDE_LENGTH,

--- a/examples/iso_diamond.rs
+++ b/examples/iso_diamond.rs
@@ -26,7 +26,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tilemap_id = TilemapId(tilemap_entity);
 
     fill_tilemap_rect(
-        TileTexture(0),
+        TileTextureIndex(0),
         TilePos { x: 0, y: 0 },
         quadrant_size,
         tilemap_id,
@@ -35,7 +35,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect(
-        TileTexture(1),
+        TileTextureIndex(1),
         TilePos {
             x: QUADRANT_SIDE_LENGTH,
             y: 0,
@@ -47,7 +47,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect(
-        TileTexture(2),
+        TileTextureIndex(2),
         TilePos {
             x: 0,
             y: QUADRANT_SIDE_LENGTH,
@@ -59,7 +59,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect(
-        TileTexture(3),
+        TileTextureIndex(3),
         TilePos {
             x: QUADRANT_SIDE_LENGTH,
             y: QUADRANT_SIDE_LENGTH,

--- a/examples/iso_staggered.rs
+++ b/examples/iso_staggered.rs
@@ -28,7 +28,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tilemap_id = TilemapId(tilemap_entity);
 
     fill_tilemap_rect(
-        TileTexture(0),
+        TileTextureIndex(0),
         TilePos { x: 0, y: 0 },
         quadrant_size,
         tilemap_id,
@@ -37,7 +37,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect(
-        TileTexture(1),
+        TileTextureIndex(1),
         TilePos {
             x: QUADRANT_SIDE_LENGTH,
             y: 0,
@@ -49,7 +49,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect(
-        TileTexture(2),
+        TileTextureIndex(2),
         TilePos {
             x: 0,
             y: QUADRANT_SIDE_LENGTH,
@@ -61,7 +61,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     fill_tilemap_rect(
-        TileTexture(3),
+        TileTextureIndex(3),
         TilePos {
             x: QUADRANT_SIDE_LENGTH,
             y: QUADRANT_SIDE_LENGTH,

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -14,7 +14,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tilemap_entity = commands.spawn().id();
 
     fill_tilemap(
-        TileTexture(0),
+        TileTextureIndex(0),
         tilemap_size,
         TilemapId(tilemap_entity),
         &mut commands,
@@ -41,7 +41,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tilemap_entity = commands.spawn().id();
 
     fill_tilemap(
-        TileTexture(2),
+        TileTextureIndex(2),
         tilemap_size,
         TilemapId(tilemap_entity),
         &mut commands,

--- a/examples/ldtk/ldtk.rs
+++ b/examples/ldtk/ldtk.rs
@@ -1,7 +1,7 @@
 use bevy_ecs_tilemap::{
     helpers::geometry::get_tilemap_center_transform,
     map::{TilemapId, TilemapSize, TilemapTexture, TilemapTileSize},
-    tiles::{TileBundle, TilePos, TileStorage, TileTexture},
+    tiles::{TileBundle, TilePos, TileStorage, TileTextureIndex},
     TilemapBundle,
 };
 use std::collections::HashMap;
@@ -192,7 +192,7 @@ pub fn process_loaded_tile_maps(
                                 .insert_bundle(TileBundle {
                                     position,
                                     tilemap_id: TilemapId(map_entity),
-                                    texture: TileTexture(tile.t as u32),
+                                    texture_index: TileTextureIndex(tile.t as u32),
                                     ..default()
                                 })
                                 .id();

--- a/examples/mouse_to_tile.rs
+++ b/examples/mouse_to_tile.rs
@@ -65,7 +65,7 @@ fn spawn_tilemap(mut commands: Commands, tile_handle_square: Res<TileHandleSquar
     let tilemap_id = TilemapId(tilemap_entity);
 
     fill_tilemap(
-        TileTexture(0),
+        TileTextureIndex(0),
         total_size,
         tilemap_id,
         &mut commands,

--- a/examples/neighbors.rs
+++ b/examples/neighbors.rs
@@ -56,7 +56,7 @@ fn spawn_tilemap(mut commands: Commands, tile_handle_hex_row: Res<TileHandleHexR
     let tilemap_id = TilemapId(tilemap_entity);
 
     fill_tilemap(
-        TileTexture(0),
+        TileTextureIndex(0),
         total_size,
         tilemap_id,
         &mut commands,

--- a/examples/random_map.rs
+++ b/examples/random_map.rs
@@ -56,7 +56,7 @@ struct LastUpdate {
 
 // In this example it's better not to use the default `MapQuery` SystemParam as
 // it's faster to do it this way:
-fn random(time: ResMut<Time>, mut query: Query<(&mut TileTexture, &mut LastUpdate)>) {
+fn random(time: ResMut<Time>, mut query: Query<(&mut TileTextureIndex, &mut LastUpdate)>) {
     let current_time = time.seconds_since_startup();
     let mut random = thread_rng();
     for (mut tile, mut last_update) in query.iter_mut() {

--- a/examples/spacing.rs
+++ b/examples/spacing.rs
@@ -14,7 +14,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tilemap_entity = commands.spawn().id();
 
     fill_tilemap(
-        TileTexture(0),
+        TileTextureIndex(0),
         tilemap_size,
         TilemapId(tilemap_entity),
         &mut commands,
@@ -42,7 +42,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tilemap_entity = commands.spawn().id();
 
     fill_tilemap(
-        TileTexture(2),
+        TileTextureIndex(2),
         tilemap_size,
         TilemapId(tilemap_entity),
         &mut commands,

--- a/examples/texture_container.rs
+++ b/examples/texture_container.rs
@@ -40,9 +40,9 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let mut rng = thread_rng();
     let weighted_tile_choices = [
-        (TileTexture(0), 0.8),
-        (TileTexture(1), 0.1),
-        (TileTexture(2), 0.1),
+        (TileTextureIndex(0), 0.8),
+        (TileTextureIndex(1), 0.1),
+        (TileTextureIndex(2), 0.1),
     ];
     for position in tile_positions {
         let texture = weighted_tile_choices
@@ -54,7 +54,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
             .insert_bundle(TileBundle {
                 position,
                 tilemap_id,
-                texture,
+                texture_index: texture,
                 ..Default::default()
             })
             .id();

--- a/examples/texture_vec.rs
+++ b/examples/texture_vec.rs
@@ -42,9 +42,9 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let mut rng = thread_rng();
     let weighted_tile_choices = [
-        (TileTexture(0), 0.8),
-        (TileTexture(1), 0.1),
-        (TileTexture(2), 0.1),
+        (TileTextureIndex(0), 0.8),
+        (TileTextureIndex(1), 0.1),
+        (TileTextureIndex(2), 0.1),
     ];
     for position in tile_positions {
         let texture = weighted_tile_choices
@@ -56,7 +56,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
             .insert_bundle(TileBundle {
                 position,
                 tilemap_id,
-                texture,
+                texture_index: texture,
                 ..Default::default()
             })
             .id();

--- a/src/helpers/filling.rs
+++ b/src/helpers/filling.rs
@@ -2,14 +2,14 @@ use crate::helpers::hex_grid::axial::AxialPos;
 use crate::helpers::hex_grid::neighbors::{HexDirection, HEX_DIRECTIONS};
 use crate::map::TilemapId;
 use crate::prelude::HexCoordSystem;
-use crate::tiles::{TileBundle, TileColor, TilePos, TileTexture};
+use crate::tiles::{TileBundle, TileColor, TilePos, TileTextureIndex};
 use crate::{TileStorage, TilemapSize};
 use bevy::hierarchy::BuildChildren;
 use bevy::prelude::{Color, Commands};
 
 /// Fills an entire tile storage with the given tile.
 pub fn fill_tilemap(
-    tile_texture: TileTexture,
+    tile_texture: TileTextureIndex,
     size: TilemapSize,
     tilemap_id: TilemapId,
     commands: &mut Commands,
@@ -23,7 +23,7 @@ pub fn fill_tilemap(
                 .insert_bundle(TileBundle {
                     position: tile_pos,
                     tilemap_id,
-                    texture: tile_texture,
+                    texture_index: tile_texture,
                     ..Default::default()
                 })
                 .id();
@@ -38,7 +38,7 @@ pub fn fill_tilemap(
 /// The rectangular region is defined by an `origin` in [`TilePos`](crate::tiles::TilePos), and a
 /// `size` in tiles ([`TilemapSize`](crate::map::TilemapSize)).  
 pub fn fill_tilemap_rect(
-    tile_texture: TileTexture,
+    tile_texture: TileTextureIndex,
     origin: TilePos,
     size: TilemapSize,
     tilemap_id: TilemapId,
@@ -57,7 +57,7 @@ pub fn fill_tilemap_rect(
                 .insert_bundle(TileBundle {
                     position: tile_pos,
                     tilemap_id,
-                    texture: tile_texture,
+                    texture_index: tile_texture,
                     ..Default::default()
                 })
                 .id();
@@ -71,7 +71,7 @@ pub fn fill_tilemap_rect(
 /// The rectangular region is defined by an `origin` in [`TilePos`](crate::tiles::TilePos), and a
 /// `size` in tiles ([`TilemapSize`](crate::map::TilemapSize)).   
 pub fn fill_tilemap_rect_color(
-    tile_texture: TileTexture,
+    tile_texture: TileTextureIndex,
     origin: TilePos,
     size: TilemapSize,
     color: Color,
@@ -91,7 +91,7 @@ pub fn fill_tilemap_rect_color(
                 .insert_bundle(TileBundle {
                     position: tile_pos,
                     tilemap_id,
-                    texture: tile_texture,
+                    texture_index: tile_texture,
                     color: TileColor(color),
                     ..Default::default()
                 })
@@ -146,7 +146,7 @@ pub fn generate_hexagon(origin: AxialPos, radius: u32) -> Vec<AxialPos> {
 ///
 /// Tiles that do not fit in the tilemap will not be created.
 pub fn fill_tilemap_hexagon(
-    tile_texture: TileTexture,
+    tile_texture: TileTextureIndex,
     origin: TilePos,
     radius: u32,
     hex_coord_system: HexCoordSystem,
@@ -168,7 +168,7 @@ pub fn fill_tilemap_hexagon(
             .insert_bundle(TileBundle {
                 position: tile_pos,
                 tilemap_id,
-                texture: tile_texture,
+                texture_index: tile_texture,
                 ..Default::default()
             })
             .id();

--- a/src/helpers/filling.rs
+++ b/src/helpers/filling.rs
@@ -9,7 +9,7 @@ use bevy::prelude::{Color, Commands};
 
 /// Fills an entire tile storage with the given tile.
 pub fn fill_tilemap(
-    tile_texture: TileTextureIndex,
+    texture_index: TileTextureIndex,
     size: TilemapSize,
     tilemap_id: TilemapId,
     commands: &mut Commands,
@@ -23,7 +23,7 @@ pub fn fill_tilemap(
                 .insert_bundle(TileBundle {
                     position: tile_pos,
                     tilemap_id,
-                    texture_index: tile_texture,
+                    texture_index,
                     ..Default::default()
                 })
                 .id();
@@ -38,7 +38,7 @@ pub fn fill_tilemap(
 /// The rectangular region is defined by an `origin` in [`TilePos`](crate::tiles::TilePos), and a
 /// `size` in tiles ([`TilemapSize`](crate::map::TilemapSize)).  
 pub fn fill_tilemap_rect(
-    tile_texture: TileTextureIndex,
+    texture_index: TileTextureIndex,
     origin: TilePos,
     size: TilemapSize,
     tilemap_id: TilemapId,
@@ -57,7 +57,7 @@ pub fn fill_tilemap_rect(
                 .insert_bundle(TileBundle {
                     position: tile_pos,
                     tilemap_id,
-                    texture_index: tile_texture,
+                    texture_index,
                     ..Default::default()
                 })
                 .id();
@@ -71,7 +71,7 @@ pub fn fill_tilemap_rect(
 /// The rectangular region is defined by an `origin` in [`TilePos`](crate::tiles::TilePos), and a
 /// `size` in tiles ([`TilemapSize`](crate::map::TilemapSize)).   
 pub fn fill_tilemap_rect_color(
-    tile_texture: TileTextureIndex,
+    texture_index: TileTextureIndex,
     origin: TilePos,
     size: TilemapSize,
     color: Color,
@@ -91,7 +91,7 @@ pub fn fill_tilemap_rect_color(
                 .insert_bundle(TileBundle {
                     position: tile_pos,
                     tilemap_id,
-                    texture_index: tile_texture,
+                    texture_index,
                     color: TileColor(color),
                     ..Default::default()
                 })
@@ -146,7 +146,7 @@ pub fn generate_hexagon(origin: AxialPos, radius: u32) -> Vec<AxialPos> {
 ///
 /// Tiles that do not fit in the tilemap will not be created.
 pub fn fill_tilemap_hexagon(
-    tile_texture: TileTextureIndex,
+    texture_index: TileTextureIndex,
     origin: TilePos,
     radius: u32,
     hex_coord_system: HexCoordSystem,
@@ -158,9 +158,9 @@ pub fn fill_tilemap_hexagon(
         AxialPos::from_tile_pos_given_coord_system(&origin, hex_coord_system),
         radius,
     )
-    .into_iter()
-    .map(|axial_pos| axial_pos.as_tile_pos_given_coord_system(hex_coord_system))
-    .collect::<Vec<TilePos>>();
+        .into_iter()
+        .map(|axial_pos| axial_pos.as_tile_pos_given_coord_system(hex_coord_system))
+        .collect::<Vec<TilePos>>();
 
     for tile_pos in tile_positions {
         let tile_entity = commands
@@ -168,7 +168,7 @@ pub fn fill_tilemap_hexagon(
             .insert_bundle(TileBundle {
                 position: tile_pos,
                 tilemap_id,
-                texture_index: tile_texture,
+                texture_index,
                 ..Default::default()
             })
             .id();

--- a/src/helpers/filling.rs
+++ b/src/helpers/filling.rs
@@ -158,9 +158,9 @@ pub fn fill_tilemap_hexagon(
         AxialPos::from_tile_pos_given_coord_system(&origin, hex_coord_system),
         radius,
     )
-        .into_iter()
-        .map(|axial_pos| axial_pos.as_tile_pos_given_coord_system(hex_coord_system))
-        .collect::<Vec<TilePos>>();
+    .into_iter()
+    .map(|axial_pos| axial_pos.as_tile_pos_given_coord_system(hex_coord_system))
+    .collect::<Vec<TilePos>>();
 
     for tile_pos in tile_positions {
         let tile_entity = commands

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -14,7 +14,7 @@ use crate::{
         TilemapId, TilemapSize, TilemapSpacing, TilemapTexture, TilemapTextureSize,
         TilemapTileSize, TilemapType,
     },
-    tiles::{TileColor, TileFlip, TilePos, TileTexture, TileVisible},
+    tiles::{TileColor, TileFlip, TilePos, TileTextureIndex, TileVisible},
     FrustumCulling,
 };
 
@@ -171,7 +171,7 @@ pub fn extract(
                 &TilePos,
                 &TilePosOld,
                 &TilemapId,
-                &TileTexture,
+                &TileTextureIndex,
                 &TileVisible,
                 &TileFlip,
                 &TileColor,
@@ -180,7 +180,7 @@ pub fn extract(
             Or<(
                 Changed<TilePos>,
                 Changed<TileVisible>,
-                Changed<TileTexture>,
+                Changed<TileTextureIndex>,
                 Changed<TileFlip>,
                 Changed<TileColor>,
             )>,

--- a/src/tiles/mod.rs
+++ b/src/tiles/mod.rs
@@ -65,7 +65,7 @@ impl From<&TilePos> for Vec2 {
 
 /// A texture index into the atlas or texture array for a single tile. Indices in an atlas are horizontal based.
 #[derive(Component, Default, Clone, Copy, Debug, Hash)]
-pub struct TileTexture(pub u32);
+pub struct TileTextureIndex(pub u32);
 
 /// A custom color for the tile.
 #[derive(Component, Default, Clone, Copy, Debug)]
@@ -95,7 +95,7 @@ pub struct TileFlip {
 #[derive(Bundle, Default, Clone, Copy, Debug)]
 pub struct TileBundle {
     pub position: TilePos,
-    pub texture: TileTexture,
+    pub texture_index: TileTextureIndex,
     pub tilemap_id: TilemapId,
     pub visible: TileVisible,
     pub flip: TileFlip,


### PR DESCRIPTION
Renamed `TileTexture` to `TileTextureIndex` and `TileBundle` member `texture` to `texture_index`.

Addresses issue: https://github.com/StarArawn/bevy_ecs_tilemap/issues/321