### PR TITLE
Disable tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,29 +30,29 @@ jobs:
           command: check
           args: --all-targets
 
-  test:
-    name: Tests
-    strategy:
-      # Tests are most likely to have OS-specific behavior
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+#   test:
+#     name: Tests
+#     strategy:
+#       # Tests are most likely to have OS-specific behavior
+#       matrix:
+#         os: [ubuntu-latest, windows-latest, macOS-latest]
         
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+#     runs-on: ${{ matrix.os }}
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@v2
         
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+#       - name: Install stable toolchain
+#         uses: actions-rs/toolchain@v1
+#         with:
+#           profile: minimal
+#           toolchain: stable
+#           override: true
 
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+#       - name: Run cargo test
+#         uses: actions-rs/cargo@v1
+#         with:
+#           command: test
 
   build_examples:
     name: Build examples


### PR DESCRIPTION
Commented it out, so we can re-introduce it later, once we actually have tests.

The benefit: for now, we get faster CI runs.