### PR TITLE
Tile maps with an even number of tiles need a half-tile offset applied.

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -101,8 +101,8 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin{
             window: WindowDescriptor {
-                width: 1270.0,
-                height: 720.0,
+                width: 540.0,
+                height: 540.0,
                 title: String::from(
                     "Basic Example - Press Space to change Texture and H to show/hide tilemap.",
                 ),

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,6 +3,9 @@ use bevy_ecs_tilemap::prelude::*;
 
 mod helpers;
 
+pub const MAP_SIZE: TilemapSize = TilemapSize { x: 32, y: 32 };
+pub const TILE_SIZE: TilemapTileSize = TilemapTileSize { x: 16.0, y: 16.0 };
+
 fn startup(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
@@ -11,8 +14,6 @@ fn startup(
     commands.spawn(Camera2dBundle::default());
 
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
-
-    let tilemap_size = TilemapSize { x: 32, y: 32 };
 
     // Create a tilemap entity a little early.
     // We want this entity early because we need to tell each tile which tilemap entity
@@ -25,12 +26,12 @@ fn startup(
     // This component is a grid of tile entities and is used to help keep track of individual
     // tiles in the world. If you have multiple layers of tiles you would have a tilemap entity
     // per layer, each with their own `TileStorage` component.
-    let mut tile_storage = TileStorage::empty(tilemap_size);
+    let mut tile_storage = TileStorage::empty(MAP_SIZE);
 
     // Spawn the elements of the tilemap.
     // Alternatively, you can use helpers::filling::fill_tilemap.
-    for x in 0..tilemap_size.x {
-        for y in 0..tilemap_size.y {
+    for x in 0..MAP_SIZE.x {
+        for y in 0..MAP_SIZE.y {
             let tile_pos = TilePos { x, y };
             let tile_entity = commands
                 .spawn(TileBundle {
@@ -43,18 +44,17 @@ fn startup(
         }
     }
 
-    let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TILE_SIZE.into();
     let map_type = TilemapType::default();
 
     commands.entity(tilemap_entity).insert(TilemapBundle {
         grid_size,
         map_type,
-        size: tilemap_size,
+        size: MAP_SIZE,
         storage: tile_storage,
         texture: TilemapTexture::Single(texture_handle),
-        tile_size,
-        transform: get_tilemap_center_transform(&tilemap_size, &grid_size, &map_type, 0.0),
+        tile_size: TILE_SIZE,
+        transform: get_tilemap_center_transform(&MAP_SIZE, &grid_size, &map_type, 0.0),
         ..Default::default()
     });
 
@@ -64,7 +64,7 @@ fn startup(
     {
         array_texture_loader.add(TilemapArrayTexture {
             texture: TilemapTexture::Single(asset_server.load("tiles.png")),
-            tile_size,
+            tile_size: TILE_SIZE,
             ..Default::default()
         });
     }
@@ -101,8 +101,8 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin{
             window: WindowDescriptor {
-                width: 540.0,
-                height: 540.0,
+                width: (MAP_SIZE.x + 1) as f32 * TILE_SIZE.x,
+                height: (MAP_SIZE.y + 1) as f32 * TILE_SIZE.y,
                 title: String::from(
                     "Basic Example - Press Space to change Texture and H to show/hide tilemap.",
                 ),

--- a/examples/texture_container.rs
+++ b/examples/texture_container.rs
@@ -4,7 +4,7 @@ mod helpers;
 mod no_atlas {
     use super::helpers;
     use bevy::prelude::*;
-    use bevy_ecs_tilemap::helpers::hex_grid::axial::AxialPos;
+    use bevy_ecs_tilemap::helpers::hex_grid::axial_system::AxialPos;
     use bevy_ecs_tilemap::prelude::*;
     use rand::prelude::SliceRandom;
     use rand::thread_rng;

--- a/examples/texture_vec.rs
+++ b/examples/texture_vec.rs
@@ -4,7 +4,7 @@ mod helpers;
 mod no_atlas {
     use super::helpers;
     use bevy::prelude::*;
-    use bevy_ecs_tilemap::helpers::hex_grid::axial::AxialPos;
+    use bevy_ecs_tilemap::helpers::hex_grid::axial_system::AxialPos;
     use bevy_ecs_tilemap::prelude::*;
     use rand::prelude::SliceRandom;
     use rand::thread_rng;

--- a/src/helpers/filling.rs
+++ b/src/helpers/filling.rs
@@ -1,4 +1,4 @@
-use crate::helpers::hex_grid::axial::AxialPos;
+use crate::helpers::hex_grid::axial_system::AxialPos;
 use crate::helpers::hex_grid::neighbors::{HexDirection, HEX_DIRECTIONS};
 use crate::map::TilemapId;
 use crate::prelude::HexCoordSystem;
@@ -129,8 +129,8 @@ pub fn generate_hex_ring(origin: AxialPos, radius: u32) -> Vec<AxialPos> {
 /// Generates a vector of hex positions that form a hexagon of given `radius` around the specified
 /// `origin`.
 pub fn generate_hexagon(origin: AxialPos, radius: u32) -> Vec<AxialPos> {
-    let mut hexagon = Vec::with_capacity((6 * radius * (radius + 1) / 2) as usize);
-    for r in 0..radius {
+    let mut hexagon = Vec::with_capacity(1 + (6 * radius * (radius + 1) / 2) as usize);
+    for r in 0..(radius + 1) {
         hexagon.extend(generate_hex_ring(origin, r));
     }
     hexagon

--- a/src/helpers/geometry.rs
+++ b/src/helpers/geometry.rs
@@ -1,34 +1,124 @@
-use crate::map::TilemapType;
+use crate::helpers::hex_grid::neighbors::{HexColDirection, HexRowDirection};
+use crate::helpers::square_grid::neighbors::SquareDirection;
+use crate::map::{HexCoordSystem, IsoCoordSystem, TilemapType};
+use crate::prelude::axial_system::AxialPos;
+use crate::prelude::diamond_system::DiamondPos;
+use crate::prelude::staggered_system::StaggeredPos;
+use crate::prelude::SquarePos;
 use crate::tiles::TilePos;
 use crate::{TilemapGridSize, TilemapSize, Transform};
 use bevy::math::Vec2;
 
-/// Gets the [`Vec2`] world space position of the center tile of the tilemap.
+/// Gets the [`Vec2`] world space position of the center of the tilemap.
 ///
 /// If the tilemap has odd dimensions, then this is just the center of the central tile in the map.
 ///
-/// Otherwise, we must add an offset of half-a-tile.
+/// Otherwise, we must add an offset of "half-a-tile", or put differently, we must center the tile
+/// on one of the corners/edges of the tile.
 pub fn get_tilemap_center(
     size: &TilemapSize,
     grid_size: &TilemapGridSize,
     map_type: &TilemapType,
 ) -> Vec2 {
-    let center_tile_pos = TilePos::new(size.x / 2.0 as u32, size.y / 2.0 as u32);
+    let center_pos = TilePos::new(size.x / 2.0 as u32, size.y / 2.0 as u32);
 
-    let mut offset = Vec2::new(0.0, 0.0);
-    // If the tilemap is even in the x-direction
-    if size.x % 2 == 0 {
-        offset.x -= grid_size.x / 2.0;
+    // Note: when tile size is even, the center tile as calculated by `center_pos` above lies
+    // *right* of the central point. Therefore, we have to move south/west to the center's location,
+    // not north/east.
+    match (size.x % 2, size.y % 2) {
+        (1, 1) => center_pos.center_in_world(grid_size, map_type),
+        (0, 1) => match map_type {
+            TilemapType::Square => {
+                let center = SquarePos::from(&center_pos);
+                center.corner_in_world(SquareDirection::West, grid_size)
+            }
+            TilemapType::Hexagon(hex_coord_system) => {
+                let center =
+                    AxialPos::from_tile_pos_given_coord_system(&center_pos, *hex_coord_system);
+                match hex_coord_system {
+                    HexCoordSystem::RowEven | HexCoordSystem::RowOdd | HexCoordSystem::Row => {
+                        (center.corner_in_world_row(HexRowDirection::SouthWest, grid_size)
+                            + center.corner_in_world_row(HexRowDirection::NorthWest, grid_size))
+                            / 2.0
+                    }
+                    _ => center.corner_in_world_col(HexColDirection::West, grid_size),
+                }
+            }
+            TilemapType::Isometric(iso_coord_system) => match iso_coord_system {
+                IsoCoordSystem::Diamond => {
+                    let center = DiamondPos::from(&center_pos);
+                    center.corner_in_world(SquareDirection::West, grid_size)
+                }
+                IsoCoordSystem::Staggered => {
+                    let center = StaggeredPos::from(&center_pos);
+                    center.corner_in_world(SquareDirection::West, grid_size)
+                }
+            },
+        },
+        (1, 0) => match map_type {
+            TilemapType::Square => {
+                let center = SquarePos::from(&center_pos);
+                center.corner_in_world(SquareDirection::South, grid_size)
+            }
+            TilemapType::Hexagon(hex_coord_system) => {
+                let center =
+                    AxialPos::from_tile_pos_given_coord_system(&center_pos, *hex_coord_system);
+                match hex_coord_system {
+                    HexCoordSystem::RowEven | HexCoordSystem::RowOdd | HexCoordSystem::Row => {
+                        center.corner_in_world_row(HexRowDirection::South, grid_size)
+                    }
+                    _ => {
+                        (center.corner_in_world_col(HexColDirection::SouthWest, grid_size)
+                            + center.corner_in_world_col(HexColDirection::SouthEast, grid_size))
+                            / 2.0
+                    }
+                }
+            }
+            TilemapType::Isometric(iso_coord_system) => match iso_coord_system {
+                IsoCoordSystem::Diamond => {
+                    let center = DiamondPos::from(&center_pos);
+                    center.corner_in_world(SquareDirection::South, grid_size)
+                }
+                IsoCoordSystem::Staggered => {
+                    let center = StaggeredPos::from(&center_pos);
+                    center.corner_in_world(SquareDirection::South, grid_size)
+                }
+            },
+        },
+        (0, 0) => match map_type {
+            TilemapType::Square => {
+                let center = SquarePos::from(&center_pos);
+                center.corner_in_world(SquareDirection::SouthWest, grid_size)
+            }
+            TilemapType::Hexagon(hex_coord_system) => {
+                let center =
+                    AxialPos::from_tile_pos_given_coord_system(&center_pos, *hex_coord_system);
+                match hex_coord_system {
+                    HexCoordSystem::RowEven | HexCoordSystem::RowOdd | HexCoordSystem::Row => {
+                        center.corner_in_world_row(HexRowDirection::SouthWest, grid_size)
+                    }
+                    _ => center.corner_in_world_col(HexColDirection::SouthWest, grid_size),
+                }
+            }
+            TilemapType::Isometric(iso_coord_system) => match iso_coord_system {
+                IsoCoordSystem::Diamond => {
+                    let center = DiamondPos::from(&center_pos);
+                    center.corner_in_world(SquareDirection::SouthWest, grid_size)
+                }
+                IsoCoordSystem::Staggered => {
+                    let center = StaggeredPos::from(&center_pos);
+                    center.corner_in_world(SquareDirection::SouthWest, grid_size)
+                }
+            },
+        },
+        (_, _) => {
+            // a number modulo 2 can only be 0 or 1
+            unreachable!()
+        }
     }
-    // If the tilemap is even in the y-direction
-    if size.y % 2 == 0 {
-        offset.y -= grid_size.y / 2.0;
-    }
-
-    center_tile_pos.center_in_world(grid_size, map_type) + offset
 }
 
-/// Calculates a [`Transform`] for a tilemap that places it so that the center tile is at
+/// Calculates a [`Transform`] for a tilemap that places it so that its center is at
 /// `(0.0, 0.0, 0.0)` in world space.
 pub fn get_tilemap_center_transform(
     size: &TilemapSize,

--- a/src/helpers/geometry.rs
+++ b/src/helpers/geometry.rs
@@ -1,13 +1,6 @@
-use crate::helpers::hex_grid::neighbors::{HexColDirection, HexRowDirection};
-use crate::helpers::square_grid::neighbors::SquareDirection;
-use crate::map::{HexCoordSystem, IsoCoordSystem, TilemapType};
-use crate::prelude::axial_system::AxialPos;
-use crate::prelude::diamond_system::DiamondPos;
-use crate::prelude::staggered_system::StaggeredPos;
-use crate::prelude::SquarePos;
+use crate::map::TilemapType;
 use crate::tiles::TilePos;
 use crate::{TilemapGridSize, TilemapSize, Transform};
-use bevy::math::Vec2;
 
 /// Calculates a [`Transform`] for a tilemap that places it so that its center is at
 /// `(0.0, 0.0, 0.0)` in world space.

--- a/src/helpers/geometry.rs
+++ b/src/helpers/geometry.rs
@@ -9,115 +9,6 @@ use crate::tiles::TilePos;
 use crate::{TilemapGridSize, TilemapSize, Transform};
 use bevy::math::Vec2;
 
-/// Gets the [`Vec2`] world space position of the center of the tilemap.
-///
-/// If the tilemap has odd dimensions, then this is just the center of the central tile in the map.
-///
-/// Otherwise, we must add an offset of "half-a-tile", or put differently, we must center the tile
-/// on one of the corners/edges of the tile.
-pub fn get_tilemap_center(
-    size: &TilemapSize,
-    grid_size: &TilemapGridSize,
-    map_type: &TilemapType,
-) -> Vec2 {
-    let center_pos = TilePos::new(size.x / 2.0 as u32, size.y / 2.0 as u32);
-
-    // Note: when tile size is even, the center tile as calculated by `center_pos` above lies
-    // *right* of the central point. Therefore, we have to move south/west to the center's location,
-    // not north/east.
-    match (size.x % 2, size.y % 2) {
-        (1, 1) => center_pos.center_in_world(grid_size, map_type),
-        (0, 1) => match map_type {
-            TilemapType::Square => {
-                let center = SquarePos::from(&center_pos);
-                center.corner_in_world(SquareDirection::West, grid_size)
-            }
-            TilemapType::Hexagon(hex_coord_system) => {
-                let center =
-                    AxialPos::from_tile_pos_given_coord_system(&center_pos, *hex_coord_system);
-                match hex_coord_system {
-                    HexCoordSystem::RowEven | HexCoordSystem::RowOdd | HexCoordSystem::Row => {
-                        (center.corner_in_world_row(HexRowDirection::SouthWest, grid_size)
-                            + center.corner_in_world_row(HexRowDirection::NorthWest, grid_size))
-                            / 2.0
-                    }
-                    _ => center.corner_in_world_col(HexColDirection::West, grid_size),
-                }
-            }
-            TilemapType::Isometric(iso_coord_system) => match iso_coord_system {
-                IsoCoordSystem::Diamond => {
-                    let center = DiamondPos::from(&center_pos);
-                    center.corner_in_world(SquareDirection::West, grid_size)
-                }
-                IsoCoordSystem::Staggered => {
-                    let center = StaggeredPos::from(&center_pos);
-                    center.corner_in_world(SquareDirection::West, grid_size)
-                }
-            },
-        },
-        (1, 0) => match map_type {
-            TilemapType::Square => {
-                let center = SquarePos::from(&center_pos);
-                center.corner_in_world(SquareDirection::South, grid_size)
-            }
-            TilemapType::Hexagon(hex_coord_system) => {
-                let center =
-                    AxialPos::from_tile_pos_given_coord_system(&center_pos, *hex_coord_system);
-                match hex_coord_system {
-                    HexCoordSystem::RowEven | HexCoordSystem::RowOdd | HexCoordSystem::Row => {
-                        center.corner_in_world_row(HexRowDirection::South, grid_size)
-                    }
-                    _ => {
-                        (center.corner_in_world_col(HexColDirection::SouthWest, grid_size)
-                            + center.corner_in_world_col(HexColDirection::SouthEast, grid_size))
-                            / 2.0
-                    }
-                }
-            }
-            TilemapType::Isometric(iso_coord_system) => match iso_coord_system {
-                IsoCoordSystem::Diamond => {
-                    let center = DiamondPos::from(&center_pos);
-                    center.corner_in_world(SquareDirection::South, grid_size)
-                }
-                IsoCoordSystem::Staggered => {
-                    let center = StaggeredPos::from(&center_pos);
-                    center.corner_in_world(SquareDirection::South, grid_size)
-                }
-            },
-        },
-        (0, 0) => match map_type {
-            TilemapType::Square => {
-                let center = SquarePos::from(&center_pos);
-                center.corner_in_world(SquareDirection::SouthWest, grid_size)
-            }
-            TilemapType::Hexagon(hex_coord_system) => {
-                let center =
-                    AxialPos::from_tile_pos_given_coord_system(&center_pos, *hex_coord_system);
-                match hex_coord_system {
-                    HexCoordSystem::RowEven | HexCoordSystem::RowOdd | HexCoordSystem::Row => {
-                        center.corner_in_world_row(HexRowDirection::SouthWest, grid_size)
-                    }
-                    _ => center.corner_in_world_col(HexColDirection::SouthWest, grid_size),
-                }
-            }
-            TilemapType::Isometric(iso_coord_system) => match iso_coord_system {
-                IsoCoordSystem::Diamond => {
-                    let center = DiamondPos::from(&center_pos);
-                    center.corner_in_world(SquareDirection::SouthWest, grid_size)
-                }
-                IsoCoordSystem::Staggered => {
-                    let center = StaggeredPos::from(&center_pos);
-                    center.corner_in_world(SquareDirection::SouthWest, grid_size)
-                }
-            },
-        },
-        (_, _) => {
-            // a number modulo 2 can only be 0 or 1
-            unreachable!()
-        }
-    }
-}
-
 /// Calculates a [`Transform`] for a tilemap that places it so that its center is at
 /// `(0.0, 0.0, 0.0)` in world space.
 pub fn get_tilemap_center_transform(
@@ -126,6 +17,10 @@ pub fn get_tilemap_center_transform(
     map_type: &TilemapType,
     z: f32,
 ) -> Transform {
-    let center = get_tilemap_center(size, grid_size, map_type);
-    Transform::from_xyz(-center.x, -center.y, z)
+    let low = TilePos::new(0, 0).center_in_world(grid_size, map_type);
+    let high = TilePos::new(size.x - 1, size.y - 1).center_in_world(grid_size, map_type);
+
+    let diff = high - low;
+
+    Transform::from_xyz(-diff.x / 2., -diff.y / 2., z)
 }

--- a/src/helpers/geometry.rs
+++ b/src/helpers/geometry.rs
@@ -3,17 +3,29 @@ use crate::tiles::TilePos;
 use crate::{TilemapGridSize, TilemapSize, Transform};
 use bevy::math::Vec2;
 
-/// Gets the [`Vec2`] world space position of the center tile in the tilemap.
+/// Gets the [`Vec2`] world space position of the center tile of the tilemap.
 ///
-/// The center tile is defined to be the tile at
-/// `TilePos { x: size.x / 2.0 as u32, y: size.y / 2.0 as u32 }`, where `size` is a `TilemapSize`.
+/// If the tilemap has odd dimensions, then this is just the center of the central tile in the map.
+///
+/// Otherwise, we must add an offset of half-a-tile.
 pub fn get_tilemap_center(
     size: &TilemapSize,
     grid_size: &TilemapGridSize,
     map_type: &TilemapType,
 ) -> Vec2 {
-    let center_pos = TilePos::new(size.x / 2.0 as u32, size.y / 2.0 as u32);
-    center_pos.center_in_world(grid_size, map_type)
+    let center_tile_pos = TilePos::new(size.x / 2.0 as u32, size.y / 2.0 as u32);
+
+    let mut offset = Vec2::new(0.0, 0.0);
+    // If the tilemap is even in the x-direction
+    if size.x % 2 == 0 {
+        offset.x -= grid_size.x / 2.0;
+    }
+    // If the tilemap is even in the y-direction
+    if size.y % 2 == 0 {
+        offset.y -= grid_size.y / 2.0;
+    }
+
+    center_tile_pos.center_in_world(grid_size, map_type) + offset
 }
 
 /// Calculates a [`Transform`] for a tilemap that places it so that the center tile is at

--- a/src/helpers/hex_grid/axial_system.rs
+++ b/src/helpers/hex_grid/axial_system.rs
@@ -1,9 +1,11 @@
+//! Code for the axial coordinate system.
+
 use crate::helpers::hex_grid::consts::{DOUBLE_INV_SQRT_3, HALF_SQRT_3, INV_SQRT_3};
-use crate::helpers::hex_grid::cube::{CubePos, FractionalCubePos};
+use crate::helpers::hex_grid::cube_system::{CubePos, FractionalCubePos};
 use crate::helpers::hex_grid::neighbors::{
     HexColDirection, HexDirection, HexRowDirection, HEX_OFFSETS,
 };
-use crate::helpers::hex_grid::offset::{ColEvenPos, ColOddPos, RowEvenPos, RowOddPos};
+use crate::helpers::hex_grid::offset_system::{ColEvenPos, ColOddPos, RowEvenPos, RowOddPos};
 use crate::map::HexCoordSystem;
 use crate::tiles::TilePos;
 use crate::{TilemapGridSize, TilemapSize};
@@ -214,26 +216,100 @@ impl AxialPos {
         (*self - *other).magnitude()
     }
 
-    /// Returns the center of the hex_grid in world space, assuming that:
-    ///     1) tiles are row-oriented ("pointy top"),
-    ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
-    pub fn center_in_world_row(&self, grid_size: &TilemapGridSize) -> Vec2 {
-        let unscaled_pos = ROW_BASIS * Vec2::new(self.q as f32, self.r as f32);
+    /// Project a vector representing a fractional axial position (i.e. the components can be `f32`)
+    /// into world space.
+    ///
+    /// This is a helper function for [`center_in_world_row`], [`corner_offset_in_world_row`] and
+    /// [`corner_in_world_row`].
+    pub fn project_row(axial_pos: Vec2, grid_size: &TilemapGridSize) -> Vec2 {
+        let unscaled_pos = ROW_BASIS * axial_pos;
         Vec2::new(
             grid_size.x * unscaled_pos.x,
             ROW_BASIS.y_axis.y * grid_size.y * unscaled_pos.y,
         )
     }
 
-    /// Returns the center of the hex_grid in world space, assuming that:
-    ///     1) tiles are column-oriented ("flat top"),
+    /// Returns the center of a hex tile world space, assuming that:
+    ///     1) tiles are row-oriented ("pointy top"),
     ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
-    pub fn center_in_world_col(&self, grid_size: &TilemapGridSize) -> Vec2 {
-        let unscaled_pos = COL_BASIS * Vec2::new(self.q as f32, self.r as f32);
+    pub fn center_in_world_row(&self, grid_size: &TilemapGridSize) -> Vec2 {
+        Self::project_row(Vec2::new(self.q as f32, self.r as f32), grid_size)
+    }
+
+    /// Returns the offset to the corner of a hex tile in the specified `corner_direction`,
+    /// in world space, assuming that tiles are row-oriented ("pointy top")
+    pub fn corner_offset_in_world_row(
+        corner_direction: HexRowDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        let corner_offset = AxialPos::from(HexDirection::from(corner_direction));
+        let corner_pos = 0.5 * Vec2::new(corner_offset.q as f32, corner_offset.r as f32);
+        Self::project_row(corner_pos, grid_size)
+    }
+
+    /// Returns the coordinate of the corner of a hex tile in the specified `corner_direction`,
+    /// in world space, assuming that:
+    ///     1) tiles are row-oriented ("pointy top"),
+    ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
+    pub fn corner_in_world_row(
+        &self,
+        corner_direction: HexRowDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        let center = Vec2::new(self.q as f32, self.r as f32);
+
+        let corner_offset = AxialPos::from(HexDirection::from(corner_direction));
+        let corner_pos = 0.5 * Vec2::new(corner_offset.q as f32, corner_offset.r as f32);
+
+        Self::project_row(center + corner_pos, grid_size)
+    }
+
+    /// Project a vector, representing a fractional axial position (i.e. the components can be `f32`)
+    /// on a column-oriented grid ("flat top"), into world space.
+    ///
+    /// This is a helper function for [`center_in_world_col`], [`corner_offset_in_world_col`] and
+    /// [`corner_in_world_col`].
+    pub fn project_col(axial_pos: Vec2, grid_size: &TilemapGridSize) -> Vec2 {
+        let unscaled_pos = COL_BASIS * axial_pos;
         Vec2::new(
             COL_BASIS.x_axis.x * grid_size.x * unscaled_pos.x,
             grid_size.y * unscaled_pos.y,
         )
+    }
+
+    /// Returns the center of a hex tile world space, assuming that:
+    ///     1) tiles are col-oriented ("flat top"),
+    ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
+    pub fn center_in_world_col(&self, grid_size: &TilemapGridSize) -> Vec2 {
+        Self::project_col(Vec2::new(self.q as f32, self.r as f32), grid_size)
+    }
+
+    /// Returns the offset to the corner of a hex tile in the specified `corner_direction`,
+    /// in world space, assuming that tiles are col-oriented ("flat top")
+    pub fn corner_offset_in_world_col(
+        corner_direction: HexColDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        let corner_offset = AxialPos::from(HexDirection::from(corner_direction));
+        let corner_pos = 0.5 * Vec2::new(corner_offset.q as f32, corner_offset.r as f32);
+        Self::project_col(corner_pos, grid_size)
+    }
+
+    /// Returns the coordinate of the corner of a hex tile in the specified `corner_direction`,
+    /// in world space, assuming that:
+    ///     1) tiles are col-oriented ("flat top"),
+    ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
+    pub fn corner_in_world_col(
+        &self,
+        corner_direction: HexColDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        let center = Vec2::new(self.q as f32, self.r as f32);
+
+        let corner_offset = AxialPos::from(HexDirection::from(corner_direction));
+        let corner_pos = 0.5 * Vec2::new(corner_offset.q as f32, corner_offset.r as f32);
+
+        Self::project_col(center + corner_pos, grid_size)
     }
 
     /// Returns the axial position of the hex_grid containing the given world position, assuming that:
@@ -344,11 +420,11 @@ impl AxialPos {
         *self + HEX_OFFSETS[direction as usize]
     }
 
-    pub fn offset_compass_row(&self, direction: HexRowDirection) -> AxialPos {
+    pub fn offset_compass_row(&self, direction: HexColDirection) -> AxialPos {
         *self + HEX_OFFSETS[direction as usize]
     }
 
-    pub fn offset_compass_col(&self, direction: HexColDirection) -> AxialPos {
+    pub fn offset_compass_col(&self, direction: HexRowDirection) -> AxialPos {
         *self + HEX_OFFSETS[direction as usize]
     }
 }

--- a/src/helpers/hex_grid/consts.rs
+++ b/src/helpers/hex_grid/consts.rs
@@ -1,5 +1,6 @@
-/// Various constants that are helpful for hex_grid-grid related calculations.
+//! Various constants that are helpful for hex_grid-grid related calculations.
 
+/// sqrt(3)
 pub const SQRT_3: f32 = 1.7320508;
 
 /// 1/sqrt(3)

--- a/src/helpers/hex_grid/cube_system.rs
+++ b/src/helpers/hex_grid/cube_system.rs
@@ -1,4 +1,6 @@
-use crate::helpers::hex_grid::axial::{AxialPos, FractionalAxialPos};
+//! Code for the cube coordinate system
+
+use crate::helpers::hex_grid::axial_system::{AxialPos, FractionalAxialPos};
 use std::ops::{Add, Mul, Sub};
 
 /// Identical to [`AxialPos`], but has an extra component `s`. Together, `q`, `r`, `s`

--- a/src/helpers/hex_grid/mod.rs
+++ b/src/helpers/hex_grid/mod.rs
@@ -1,5 +1,7 @@
-pub mod axial;
+//! Code for managing hexagonal coordinate systems
+
+pub mod axial_system;
 pub mod consts;
-pub mod cube;
+pub mod cube_system;
 pub mod neighbors;
-pub mod offset;
+pub mod offset_system;

--- a/src/helpers/hex_grid/neighbors.rs
+++ b/src/helpers/hex_grid/neighbors.rs
@@ -1,5 +1,7 @@
-use crate::helpers::hex_grid::axial::AxialPos;
-use crate::helpers::hex_grid::offset::{ColEvenPos, ColOddPos, RowEvenPos, RowOddPos};
+//! Code for managing neighbors on a hexagonal grid.
+
+use crate::helpers::hex_grid::axial_system::AxialPos;
+use crate::helpers::hex_grid::offset_system::{ColEvenPos, ColOddPos, RowEvenPos, RowOddPos};
 use crate::map::{HexCoordSystem, TilemapSize};
 use crate::prelude::TileStorage;
 use crate::TilePos;
@@ -163,20 +165,6 @@ impl HexDirection {
 /// [RowOdd](crate::map::HexCoordSystem::RowOdd)).
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, Eq, PartialEq, Hash)]
 pub enum HexRowDirection {
-    East,
-    NorthEast,
-    NorthWest,
-    West,
-    SouthWest,
-    SouthEast,
-}
-
-/// Compass directions of a tile in hexagonal column-oriented coordinate systems
-/// ([Column](crate::map::HexCoordSystem::Column),
-/// [ColumnEven](crate::map::HexCoordSystem::ColumnEven), and
-/// [ColumnOdd](crate::map::HexCoordSystem::ColumnOdd)).
-#[derive(Clone, Copy, Debug, PartialOrd, Ord, Eq, PartialEq, Hash)]
-pub enum HexColDirection {
     North,
     NorthWest,
     SouthWest,
@@ -185,30 +173,23 @@ pub enum HexColDirection {
     NorthEast,
 }
 
+/// Compass directions of a tile in hexagonal column-oriented coordinate systems
+/// ([Column](crate::map::HexCoordSystem::Column),
+/// [ColumnEven](crate::map::HexCoordSystem::ColumnEven), and
+/// [ColumnOdd](crate::map::HexCoordSystem::ColumnOdd)).
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, Eq, PartialEq, Hash)]
+pub enum HexColDirection {
+    East,
+    NorthEast,
+    NorthWest,
+    West,
+    SouthWest,
+    SouthEast,
+}
+
 impl From<HexDirection> for HexRowDirection {
     fn from(direction: HexDirection) -> Self {
-        use HexDirection::*;
         use HexRowDirection::*;
-        match direction {
-            Zero => East,
-            One => NorthEast,
-            Two => NorthWest,
-            Three => West,
-            Four => SouthWest,
-            Five => SouthEast,
-        }
-    }
-}
-
-impl From<HexRowDirection> for HexDirection {
-    fn from(direction: HexRowDirection) -> Self {
-        (direction as usize).into()
-    }
-}
-
-impl From<HexDirection> for HexColDirection {
-    fn from(direction: HexDirection) -> Self {
-        use HexColDirection::*;
         use HexDirection::*;
         match direction {
             Zero => North,
@@ -221,13 +202,13 @@ impl From<HexDirection> for HexColDirection {
     }
 }
 
-impl From<HexColDirection> for HexDirection {
-    fn from(direction: HexColDirection) -> Self {
+impl From<HexRowDirection> for HexDirection {
+    fn from(direction: HexRowDirection) -> Self {
         (direction as usize).into()
     }
 }
 
-impl HexRowDirection {
+impl HexColDirection {
     pub fn offset(&self, tile_pos: &TilePos, coord_sys: HexCoordSystem) -> TilePos {
         AxialPos::from_tile_pos_given_coord_system(tile_pos, coord_sys)
             .offset_compass_row(*self)
@@ -235,11 +216,32 @@ impl HexRowDirection {
     }
 }
 
-impl HexColDirection {
+impl HexRowDirection {
     pub fn offset(&self, tile_pos: &TilePos, coord_sys: HexCoordSystem) -> TilePos {
         AxialPos::from_tile_pos_given_coord_system(tile_pos, coord_sys)
             .offset_compass_col(*self)
             .as_tile_pos_given_coord_system(coord_sys)
+    }
+}
+
+impl From<HexDirection> for HexColDirection {
+    fn from(direction: HexDirection) -> Self {
+        use HexDirection::*;
+        use HexColDirection::*;
+        match direction {
+            Zero => East,
+            One => NorthEast,
+            Two => NorthWest,
+            Three => West,
+            Four => SouthWest,
+            Five => SouthEast,
+        }
+    }
+}
+
+impl From<HexColDirection> for HexDirection {
+    fn from(direction: HexColDirection) -> Self {
+        (direction as usize).into()
     }
 }
 

--- a/src/helpers/hex_grid/neighbors.rs
+++ b/src/helpers/hex_grid/neighbors.rs
@@ -189,8 +189,8 @@ pub enum HexColDirection {
 
 impl From<HexDirection> for HexRowDirection {
     fn from(direction: HexDirection) -> Self {
-        use HexRowDirection::*;
         use HexDirection::*;
+        use HexRowDirection::*;
         match direction {
             Zero => North,
             One => NorthWest,
@@ -226,8 +226,8 @@ impl HexRowDirection {
 
 impl From<HexDirection> for HexColDirection {
     fn from(direction: HexDirection) -> Self {
-        use HexDirection::*;
         use HexColDirection::*;
+        use HexDirection::*;
         match direction {
             Zero => East,
             One => NorthEast,

--- a/src/helpers/hex_grid/offset_system.rs
+++ b/src/helpers/hex_grid/offset_system.rs
@@ -1,4 +1,6 @@
-use crate::helpers::hex_grid::axial::AxialPos;
+//! Code for the offset coordinate system.
+
+use crate::helpers::hex_grid::axial_system::AxialPos;
 use crate::helpers::hex_grid::neighbors::{HexColDirection, HexDirection, HexRowDirection};
 use crate::tiles::TilePos;
 use crate::{TilemapGridSize, TilemapSize};
@@ -15,6 +17,26 @@ impl RowOddPos {
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
         let axial_pos = AxialPos::from(*self);
         axial_pos.center_in_world_row(grid_size)
+    }
+
+    /// Returns the offset to the corner of a hex tile in the specified `corner_direction`,
+    /// in world space
+    pub fn corner_offset_in_world(
+        corner_direction: HexRowDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        AxialPos::corner_offset_in_world_row(corner_direction, grid_size)
+    }
+
+    /// Returns the position of the corner of a hex tile in the specified `corner_direction`,
+    /// in world space
+    pub fn corner_in_world(
+        &self,
+        corner_direction: HexRowDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        let axial_pos = AxialPos::from(*self);
+        axial_pos.corner_in_world_row(corner_direction, grid_size)
     }
 
     /// Returns the tile containing the given world position.
@@ -47,7 +69,7 @@ impl RowOddPos {
     }
 
     /// Get the tile offset from `self` in the given [`HexRowDirection`].
-    pub fn offset_compass(&self, direction: HexRowDirection) -> Self {
+    pub fn offset_compass(&self, direction: HexColDirection) -> Self {
         Self::from(AxialPos::from(*self).offset(direction.into()))
     }
 }
@@ -72,6 +94,26 @@ impl RowEvenPos {
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
         let axial_pos = AxialPos::from(*self);
         axial_pos.center_in_world_row(grid_size)
+    }
+
+    /// Returns the offset to the corner of a hex tile in the specified `corner_direction`,
+    /// in world space
+    pub fn corner_offset_in_world(
+        corner_direction: HexRowDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        AxialPos::corner_offset_in_world_row(corner_direction, grid_size)
+    }
+
+    /// Returns the position of the corner of a hex tile in the specified `corner_direction`,
+    /// in world space
+    pub fn corner_in_world(
+        &self,
+        corner_direction: HexRowDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        let axial_pos = AxialPos::from(*self);
+        axial_pos.corner_in_world_row(corner_direction, grid_size)
     }
 
     /// Returns the tile containing the given world position.
@@ -104,7 +146,7 @@ impl RowEvenPos {
     }
 
     /// Get the tile offset from `self` in the given [`HexRowDirection`].
-    pub fn offset_compass(&self, direction: HexRowDirection) -> Self {
+    pub fn offset_compass(&self, direction: HexColDirection) -> Self {
         Self::from(AxialPos::from(*self).offset(direction.into()))
     }
 }
@@ -129,6 +171,26 @@ impl ColOddPos {
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
         let axial_pos = AxialPos::from(*self);
         axial_pos.center_in_world_col(grid_size)
+    }
+
+    /// Returns the offset to the corner of a hex tile in the specified `corner_direction`,
+    /// in world space
+    pub fn corner_offset_in_world(
+        corner_direction: HexColDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        AxialPos::corner_offset_in_world_col(corner_direction, grid_size)
+    }
+
+    /// Returns the position of the corner of a hex tile in the specified `corner_direction`,
+    /// in world space
+    pub fn corner_in_world(
+        &self,
+        corner_direction: HexColDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        let axial_pos = AxialPos::from(*self);
+        axial_pos.corner_in_world_col(corner_direction, grid_size)
     }
 
     /// Returns the tile containing the given world position.
@@ -161,7 +223,7 @@ impl ColOddPos {
     }
 
     /// Get the tile offset from `self` in the given [`HexColDirection`].
-    pub fn offset_compass(&self, direction: HexColDirection) -> Self {
+    pub fn offset_compass(&self, direction: HexRowDirection) -> Self {
         Self::from(AxialPos::from(*self).offset(direction.into()))
     }
 }
@@ -186,6 +248,26 @@ impl ColEvenPos {
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
         let axial_pos = AxialPos::from(*self);
         axial_pos.center_in_world_col(grid_size)
+    }
+
+    /// Returns the offset to the corner of a hex tile in the specified `corner_direction`,
+    /// in world space
+    pub fn corner_offset_in_world(
+        corner_direction: HexColDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        AxialPos::corner_offset_in_world_col(corner_direction, grid_size)
+    }
+
+    /// Returns the position of the corner of a hex tile in the specified `corner_direction`,
+    /// in world space
+    pub fn corner_in_world(
+        &self,
+        corner_direction: HexColDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        let axial_pos = AxialPos::from(*self);
+        axial_pos.corner_in_world_col(corner_direction, grid_size)
     }
 
     /// Returns the tile containing the given world position.
@@ -218,7 +300,7 @@ impl ColEvenPos {
     }
 
     /// Get the tile offset from `self` in the given [`HexColDirection`].
-    pub fn offset_compass(&self, direction: HexColDirection) -> Self {
+    pub fn offset_compass(&self, direction: HexRowDirection) -> Self {
         Self::from(AxialPos::from(*self).offset(direction.into()))
     }
 }

--- a/src/helpers/projection.rs
+++ b/src/helpers/projection.rs
@@ -1,7 +1,7 @@
-use crate::helpers::hex_grid::axial::AxialPos;
-use crate::helpers::hex_grid::offset::{ColEvenPos, ColOddPos, RowEvenPos, RowOddPos};
-use crate::helpers::square_grid::diamond::DiamondPos;
-use crate::helpers::square_grid::staggered::StaggeredPos;
+use crate::helpers::hex_grid::axial_system::AxialPos;
+use crate::helpers::hex_grid::offset_system::{ColEvenPos, ColOddPos, RowEvenPos, RowOddPos};
+use crate::helpers::square_grid::diamond_system::DiamondPos;
+use crate::helpers::square_grid::staggered_system::StaggeredPos;
 use crate::map::{HexCoordSystem, IsoCoordSystem};
 use crate::tiles::TilePos;
 use crate::{TilemapGridSize, TilemapSize, TilemapType};

--- a/src/helpers/square_grid/neighbors.rs
+++ b/src/helpers/square_grid/neighbors.rs
@@ -1,4 +1,4 @@
-use crate::helpers::square_grid::staggered::StaggeredPos;
+use crate::helpers::square_grid::staggered_system::StaggeredPos;
 use crate::helpers::square_grid::SquarePos;
 use crate::map::TilemapSize;
 use crate::prelude::{TilePos, TileStorage};

--- a/src/helpers/square_grid/staggered_system.rs
+++ b/src/helpers/square_grid/staggered_system.rs
@@ -1,4 +1,4 @@
-use crate::helpers::square_grid::diamond::DiamondPos;
+use crate::helpers::square_grid::diamond_system::DiamondPos;
 use crate::helpers::square_grid::neighbors::{SquareDirection, SQUARE_OFFSETS};
 use crate::helpers::square_grid::SquarePos;
 use crate::tiles::TilePos;
@@ -92,6 +92,32 @@ impl StaggeredPos {
     /// Returns the position of this tile's center, in world space.
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
         DiamondPos::from(self).center_in_world(grid_size)
+    }
+
+    /// Returns the offset to the corner of a tile in the specified `corner_direction`,
+    /// in world space
+    pub fn corner_offset_in_world(
+        corner_direction: SquareDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        DiamondPos::corner_offset_in_world(corner_direction, grid_size)
+    }
+
+    /// Returns the coordinate of the corner of a tile in the specified `corner_direction`,
+    /// in world space
+    pub fn corner_in_world(
+        &self,
+        corner_direction: SquareDirection,
+        grid_size: &TilemapGridSize,
+    ) -> Vec2 {
+        let diamond_pos = DiamondPos::from(self);
+
+        let center = Vec2::new(diamond_pos.x as f32, diamond_pos.y as f32);
+
+        let corner_offset = DiamondPos::from(SquarePos::from(corner_direction));
+        let corner_pos = 0.5 * Vec2::new(corner_offset.x as f32, corner_offset.y as f32);
+
+        DiamondPos::project(center + corner_pos, grid_size)
     }
 
     /// Returns the tile containing the given world position.


### PR DESCRIPTION
Fixes #342 