### PR TITLE
Some improvements to ergonomics of neighbor related helpers. 

### DIFF
--- a/src/helpers/hex_grid/axial.rs
+++ b/src/helpers/hex_grid/axial.rs
@@ -95,6 +95,7 @@ impl Mul<AxialPos> for u32 {
     }
 }
 
+#[inline]
 fn ceiled_division_by_2(x: i32) -> i32 {
     if x < 0 {
         (x - 1) / 2
@@ -104,6 +105,7 @@ fn ceiled_division_by_2(x: i32) -> i32 {
 }
 
 impl From<AxialPos> for RowOddPos {
+    #[inline]
     fn from(axial_pos: AxialPos) -> Self {
         let AxialPos { q, r } = axial_pos;
         let delta = r / 2;
@@ -112,6 +114,7 @@ impl From<AxialPos> for RowOddPos {
 }
 
 impl From<RowOddPos> for AxialPos {
+    #[inline]
     fn from(offset_pos: RowOddPos) -> Self {
         let RowOddPos { q, r } = offset_pos;
         let delta = r / 2;
@@ -120,6 +123,7 @@ impl From<RowOddPos> for AxialPos {
 }
 
 impl From<AxialPos> for RowEvenPos {
+    #[inline]
     fn from(axial_pos: AxialPos) -> Self {
         let AxialPos { q, r } = axial_pos;
         // (n + 1) / 2 is a ceil'ed rather than floored division
@@ -129,6 +133,7 @@ impl From<AxialPos> for RowEvenPos {
 }
 
 impl From<RowEvenPos> for AxialPos {
+    #[inline]
     fn from(offset_pos: RowEvenPos) -> Self {
         let RowEvenPos { q, r } = offset_pos;
         let delta = ceiled_division_by_2(r);
@@ -137,6 +142,7 @@ impl From<RowEvenPos> for AxialPos {
 }
 
 impl From<AxialPos> for ColOddPos {
+    #[inline]
     fn from(axial_pos: AxialPos) -> Self {
         let AxialPos { q, r } = axial_pos;
         let delta = q / 2;
@@ -145,6 +151,7 @@ impl From<AxialPos> for ColOddPos {
 }
 
 impl From<ColOddPos> for AxialPos {
+    #[inline]
     fn from(offset_pos: ColOddPos) -> Self {
         let ColOddPos { q, r } = offset_pos;
         let delta = q / 2;
@@ -153,6 +160,7 @@ impl From<ColOddPos> for AxialPos {
 }
 
 impl From<AxialPos> for ColEvenPos {
+    #[inline]
     fn from(axial_pos: AxialPos) -> Self {
         let AxialPos { q, r } = axial_pos;
         let delta = ceiled_division_by_2(q);
@@ -161,6 +169,7 @@ impl From<AxialPos> for ColEvenPos {
 }
 
 impl From<ColEvenPos> for AxialPos {
+    #[inline]
     fn from(offset_pos: ColEvenPos) -> Self {
         let ColEvenPos { q, r } = offset_pos;
         let delta = ceiled_division_by_2(q);
@@ -206,12 +215,14 @@ impl AxialPos {
     /// The magnitude of a cube position is its distance away from the `(0, 0)` hex_grid.
     ///
     /// See the Red Blob Games article for a [helpful interactive diagram](https://www.redblobgames.com/grids/hexagons/#distances-cube).
+    #[inline]
     pub fn magnitude(&self) -> i32 {
         let cube_pos = CubePos::from(*self);
         cube_pos.magnitude()
     }
 
     /// Returns the hex_grid distance between `self` and `other`.
+    #[inline]
     pub fn distance_from(&self, other: &AxialPos) -> i32 {
         (*self - *other).magnitude()
     }
@@ -221,6 +232,7 @@ impl AxialPos {
     ///
     /// This is a helper function for [`center_in_world_row`], [`corner_offset_in_world_row`] and
     /// [`corner_in_world_row`].
+    #[inline]
     pub fn project_row(axial_pos: Vec2, grid_size: &TilemapGridSize) -> Vec2 {
         let unscaled_pos = ROW_BASIS * axial_pos;
         Vec2::new(
@@ -232,12 +244,14 @@ impl AxialPos {
     /// Returns the center of a hex tile world space, assuming that:
     ///     1) tiles are row-oriented ("pointy top"),
     ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
+    #[inline]
     pub fn center_in_world_row(&self, grid_size: &TilemapGridSize) -> Vec2 {
         Self::project_row(Vec2::new(self.q as f32, self.r as f32), grid_size)
     }
 
     /// Returns the offset to the corner of a hex tile in the specified `corner_direction`,
     /// in world space, assuming that tiles are row-oriented ("pointy top")
+    #[inline]
     pub fn corner_offset_in_world_row(
         corner_direction: HexRowDirection,
         grid_size: &TilemapGridSize,
@@ -251,6 +265,7 @@ impl AxialPos {
     /// in world space, assuming that:
     ///     1) tiles are row-oriented ("pointy top"),
     ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
+    #[inline]
     pub fn corner_in_world_row(
         &self,
         corner_direction: HexRowDirection,
@@ -269,6 +284,7 @@ impl AxialPos {
     ///
     /// This is a helper function for [`center_in_world_col`], [`corner_offset_in_world_col`] and
     /// [`corner_in_world_col`].
+    #[inline]
     pub fn project_col(axial_pos: Vec2, grid_size: &TilemapGridSize) -> Vec2 {
         let unscaled_pos = COL_BASIS * axial_pos;
         Vec2::new(
@@ -280,12 +296,14 @@ impl AxialPos {
     /// Returns the center of a hex tile world space, assuming that:
     ///     1) tiles are col-oriented ("flat top"),
     ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
+    #[inline]
     pub fn center_in_world_col(&self, grid_size: &TilemapGridSize) -> Vec2 {
         Self::project_col(Vec2::new(self.q as f32, self.r as f32), grid_size)
     }
 
     /// Returns the offset to the corner of a hex tile in the specified `corner_direction`,
     /// in world space, assuming that tiles are col-oriented ("flat top")
+    #[inline]
     pub fn corner_offset_in_world_col(
         corner_direction: HexColDirection,
         grid_size: &TilemapGridSize,
@@ -299,6 +317,7 @@ impl AxialPos {
     /// in world space, assuming that:
     ///     1) tiles are col-oriented ("flat top"),
     ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
+    #[inline]
     pub fn corner_in_world_col(
         &self,
         corner_direction: HexColDirection,
@@ -315,6 +334,7 @@ impl AxialPos {
     /// Returns the axial position of the hex_grid containing the given world position, assuming that:
     ///     1) tiles are row-oriented ("pointy top") and that
     ///     2) the world position corresponding to `[0.0, 0.0]` lies in the hex_grid indexed `(0, 0)`.
+    #[inline]
     pub fn from_world_pos_row(world_pos: &Vec2, grid_size: &TilemapGridSize) -> AxialPos {
         let normalized_world_pos = Vec2::new(
             world_pos.x / grid_size.x,
@@ -327,6 +347,7 @@ impl AxialPos {
     /// Returns the axial position of the hex_grid containing the given world position, assuming that:
     ///     1) tiles are column-oriented ("flat top") and that
     ///     2) the world position corresponding to `[0.0, 0.0]` lies in the hex_grid indexed `(0, 0)`.
+    #[inline]
     pub fn from_world_pos_col(world_pos: &Vec2, grid_size: &TilemapGridSize) -> AxialPos {
         let normalized_world_pos = Vec2::new(
             world_pos.x / (COL_BASIS.x_axis.x * grid_size.x),
@@ -340,6 +361,7 @@ impl AxialPos {
     ///
     /// Returns `None` if either one of `q` or `r` is negative, or lies out of the bounds of
     /// `map_size`.
+    #[inline]
     pub fn as_tile_pos_given_map_size(&self, map_size: &TilemapSize) -> Option<TilePos> {
         TilePos::from_i32_pair(self.q, self.r, map_size)
     }
@@ -347,6 +369,7 @@ impl AxialPos {
     /// Convert naively into a [`TilePos`].
     ///
     /// `q` becomes `x` and `r` becomes `y`.
+    #[inline]
     pub fn as_tile_pos_unchecked(&self) -> TilePos {
         TilePos {
             x: self.q as u32,
@@ -360,6 +383,7 @@ impl AxialPos {
     /// [`RowOdd`](HexCoordSystem::RowOdd), or [`ColumnEven`](HexCoordSystem::ColumnEven),
     /// [`ColumnOdd`](HexCoordSystem::ColumnOdd), `self` will be converted into the appropriate
     /// coordinate system before being returned as a `TilePos`.
+    #[inline]
     pub fn as_tile_pos_given_coord_system(&self, hex_coord_sys: HexCoordSystem) -> TilePos {
         match hex_coord_sys {
             HexCoordSystem::RowEven => RowEvenPos::from(*self).as_tile_pos_unchecked(),
@@ -377,6 +401,7 @@ impl AxialPos {
     /// [`RowOdd`](HexCoordSystem::RowOdd), or [`ColumnEven`](HexCoordSystem::ColumnEven),
     /// [`ColumnOdd`](HexCoordSystem::ColumnOdd), `self` will be converted into the appropriate
     /// coordinate system before being returned as a `TilePos`.
+    #[inline]
     pub fn as_tile_pos_given_coord_system_and_map_size(
         &self,
         hex_coord_sys: HexCoordSystem,
@@ -403,6 +428,7 @@ impl AxialPos {
     /// [`RowOdd`](HexCoordSystem::RowOdd), or [`ColumnEven`](HexCoordSystem::ColumnEven),
     /// [`ColumnOdd`](HexCoordSystem::ColumnOdd), `self` will be converted into the appropriate
     /// coordinate system before being returned as a `TilePos`.
+    #[inline]
     pub fn from_tile_pos_given_coord_system(
         tile_pos: &TilePos,
         hex_coord_sys: HexCoordSystem,
@@ -416,14 +442,17 @@ impl AxialPos {
         }
     }
 
+    #[inline]
     pub fn offset(&self, direction: HexDirection) -> AxialPos {
         *self + HEX_OFFSETS[direction as usize]
     }
 
+    #[inline]
     pub fn offset_compass_row(&self, direction: HexRowDirection) -> AxialPos {
         *self + HEX_OFFSETS[direction as usize]
     }
 
+    #[inline]
     pub fn offset_compass_col(&self, direction: HexColDirection) -> AxialPos {
         *self + HEX_OFFSETS[direction as usize]
     }
@@ -440,6 +469,7 @@ pub struct FractionalAxialPos {
 }
 
 impl FractionalAxialPos {
+    #[inline]
     fn round(&self) -> AxialPos {
         let frac_cube_pos = FractionalCubePos::from(*self);
         let cube_pos = frac_cube_pos.round();
@@ -448,12 +478,14 @@ impl FractionalAxialPos {
 }
 
 impl From<Vec2> for FractionalAxialPos {
+    #[inline]
     fn from(v: Vec2) -> Self {
         FractionalAxialPos { q: v.x, r: v.y }
     }
 }
 
 impl From<AxialPos> for FractionalAxialPos {
+    #[inline]
     fn from(axial_pos: AxialPos) -> Self {
         FractionalAxialPos {
             q: axial_pos.q as f32,

--- a/src/helpers/hex_grid/cube.rs
+++ b/src/helpers/hex_grid/cube.rs
@@ -24,6 +24,7 @@ pub struct CubePos {
 }
 
 impl From<AxialPos> for CubePos {
+    #[inline]
     fn from(axial_pos: AxialPos) -> Self {
         let AxialPos { q, r } = axial_pos;
         CubePos { q, r, s: -(q + r) }
@@ -94,11 +95,13 @@ impl CubePos {
     /// The magnitude of a cube position is its distance away from the `[0, 0, 0]` hex_grid.
     ///
     /// See the Red Blob Games article for a [helpful interactive diagram](https://www.redblobgames.com/grids/hexagons/#distances-cube).
+    #[inline]
     pub fn magnitude(&self) -> i32 {
         self.q.abs().max(self.r.abs().max(self.s.abs()))
     }
 
     /// Returns the hex_grid distance between `self` and `other`.
+    #[inline]
     pub fn distance_from(&self, other: &CubePos) -> i32 {
         let cube_pos: CubePos = *self - *other;
         cube_pos.magnitude()
@@ -122,6 +125,7 @@ impl From<FractionalAxialPos> for FractionalCubePos {
 impl FractionalCubePos {
     /// Returns `self` rounded to a [`CubePos`] that contains `self`. This is particularly useful
     /// for determining the hex tile that this fractional position is in.
+    #[inline]
     pub fn round(&self) -> CubePos {
         let q_round = self.q.round();
         let r_round = self.r.round();

--- a/src/helpers/hex_grid/neighbors.rs
+++ b/src/helpers/hex_grid/neighbors.rs
@@ -186,6 +186,7 @@ pub enum HexColDirection {
 }
 
 impl From<HexDirection> for HexRowDirection {
+    #[inline]
     fn from(direction: HexDirection) -> Self {
         use HexDirection::*;
         use HexRowDirection::*;
@@ -201,6 +202,7 @@ impl From<HexDirection> for HexRowDirection {
 }
 
 impl From<HexDirection> for HexColDirection {
+    #[inline]
     fn from(direction: HexDirection) -> Self {
         use HexColDirection::*;
         use HexDirection::*;
@@ -216,18 +218,21 @@ impl From<HexDirection> for HexColDirection {
 }
 
 impl From<HexRowDirection> for HexDirection {
+    #[inline]
     fn from(direction: HexRowDirection) -> Self {
         (direction as usize).into()
     }
 }
 
 impl From<HexColDirection> for HexDirection {
+    #[inline]
     fn from(direction: HexColDirection) -> Self {
         (direction as usize).into()
     }
 }
 
 impl HexRowDirection {
+    #[inline]
     pub fn offset(&self, tile_pos: &TilePos, coord_sys: HexCoordSystem) -> TilePos {
         AxialPos::from_tile_pos_given_coord_system(tile_pos, coord_sys)
             .offset_compass_row(*self)
@@ -236,6 +241,7 @@ impl HexRowDirection {
 }
 
 impl HexColDirection {
+    #[inline]
     pub fn offset(&self, tile_pos: &TilePos, coord_sys: HexCoordSystem) -> TilePos {
         AxialPos::from_tile_pos_given_coord_system(tile_pos, coord_sys)
             .offset_compass_col(*self)
@@ -258,6 +264,7 @@ impl<T> HexNeighbors<T> {
     /// Get an item that lies in a particular hex direction, specified by a [`HexDirection`].
     ///
     /// Will be `None` if no such items exists.
+    #[inline]
     pub fn get(&self, direction: HexDirection) -> Option<&T> {
         use HexDirection::*;
         match direction {
@@ -273,6 +280,7 @@ impl<T> HexNeighbors<T> {
     /// Get a mutable reference to an item that lies in a particular hex direction.
     ///
     /// Will be `None` if no such items exists.
+    #[inline]
     pub fn get_inner_mut(&mut self, direction: HexDirection) -> Option<&mut T> {
         use HexDirection::*;
         match direction {
@@ -288,6 +296,7 @@ impl<T> HexNeighbors<T> {
     /// Get a mutable reference to the optional item that lies in a particular hex direction.
     ///
     /// Will be `None` if no such items exists.
+    #[inline]
     pub fn get_mut(&mut self, direction: HexDirection) -> &mut Option<T> {
         use HexDirection::*;
         match direction {
@@ -303,6 +312,7 @@ impl<T> HexNeighbors<T> {
     /// Set item that lies in a particular hex direction.
     ///
     /// This does an [`Option::replace`](Option::replace) under the hood.
+    #[inline]
     pub fn set(&mut self, direction: HexDirection, data: T) {
         self.get_mut(direction).replace(data);
     }
@@ -310,6 +320,7 @@ impl<T> HexNeighbors<T> {
     /// Iterate over neighbors, in the order specified by [`HEX_DIRECTIONS`].
     ///
     /// If a neighbor is `None`, this iterator will skip it.
+    #[inline]
     pub fn iter(&self) -> impl Iterator<Item = &'_ T> + '_ {
         HEX_DIRECTIONS
             .into_iter()
@@ -318,6 +329,7 @@ impl<T> HexNeighbors<T> {
 
     /// Applies the supplied closure `f` with an [`and_then`](std::option::Option::and_then) to each
     /// neighbor element, where `f` takes `T` by value.
+    #[inline]
     pub fn and_then<U, F>(self, f: F) -> HexNeighbors<U>
     where
         F: Fn(T) -> Option<U>,
@@ -334,6 +346,7 @@ impl<T> HexNeighbors<T> {
 
     /// Applies the supplied closure `f` with an [`and_then`](std::option::Option::and_then) to each
     /// neighbor element, where `f` takes `T` by reference.
+    #[inline]
     pub fn and_then_ref<'a, U, F>(&'a self, f: F) -> HexNeighbors<U>
     where
         F: Fn(&'a T) -> Option<U>,
@@ -350,6 +363,7 @@ impl<T> HexNeighbors<T> {
 
     /// Applies the supplied closure `f` with a [`map`](std::option::Option::map) to each
     /// neighbor element, where `f` takes `T` by reference.
+    #[inline]
     pub fn map_ref<'a, U, F>(&'a self, f: F) -> HexNeighbors<U>
     where
         F: Fn(&'a T) -> U,
@@ -366,6 +380,7 @@ impl<T> HexNeighbors<T> {
 
     /// Generates `HexNeighbors<T>` from a closure that takes a hex direction and outputs
     /// `Option<T>`.
+    #[inline]
     pub fn from_directional_closure<F>(f: F) -> HexNeighbors<T>
     where
         F: Fn(HexDirection) -> Option<T>,
@@ -395,6 +410,7 @@ impl HexNeighbors<TilePos> {
     ///
     /// A tile position will be `None` for a particular direction, if that neighbor would not lie
     /// on the map.
+    #[inline]
     pub fn get_neighboring_positions(
         tile_pos: &TilePos,
         map_size: &TilemapSize,
@@ -433,6 +449,7 @@ impl HexNeighbors<TilePos> {
     ///
     /// A tile position will be `None` for a particular direction, if that neighbor would not lie
     /// on the map.
+    #[inline]
     pub fn get_neighboring_positions_standard(
         tile_pos: &TilePos,
         map_size: &TilemapSize,
@@ -450,6 +467,7 @@ impl HexNeighbors<TilePos> {
     ///
     /// A tile position will be `None` for a particular direction, if that neighbor would not lie
     /// on the map.
+    #[inline]
     pub fn get_neighboring_positions_row_even(
         tile_pos: &TilePos,
         map_size: &TilemapSize,
@@ -465,6 +483,7 @@ impl HexNeighbors<TilePos> {
     ///
     /// A tile position will be `None` for a particular direction, if that neighbor would not lie
     /// on the map.
+    #[inline]
     pub fn get_neighboring_positions_row_odd(
         tile_pos: &TilePos,
         map_size: &TilemapSize,
@@ -480,6 +499,7 @@ impl HexNeighbors<TilePos> {
     ///
     /// A tile position will be `None` for a particular direction, if that neighbor would not lie
     /// on the map.
+    #[inline]
     pub fn get_neighboring_positions_col_even(
         tile_pos: &TilePos,
         map_size: &TilemapSize,
@@ -495,6 +515,7 @@ impl HexNeighbors<TilePos> {
     ///
     /// A tile position will be `None` for a particular direction, if that neighbor would not lie
     /// on the map.
+    #[inline]
     pub fn get_neighboring_positions_col_odd(
         tile_pos: &TilePos,
         map_size: &TilemapSize,
@@ -507,6 +528,7 @@ impl HexNeighbors<TilePos> {
     }
 
     /// Returns the entities associated with each tile position.
+    #[inline]
     pub fn entities(&self, tile_storage: &TileStorage) -> HexNeighbors<Entity> {
         let f = |tile_pos| tile_storage.get(tile_pos);
         self.and_then_ref(f)

--- a/src/helpers/hex_grid/neighbors.rs
+++ b/src/helpers/hex_grid/neighbors.rs
@@ -252,12 +252,12 @@ impl HexColDirection {
 /// Stores some data `T` associated with each neighboring hex cell, if present.
 #[derive(Debug, Default)]
 pub struct HexNeighbors<T> {
-    zero: Option<T>,
-    one: Option<T>,
-    two: Option<T>,
-    three: Option<T>,
-    four: Option<T>,
-    five: Option<T>,
+    pub zero: Option<T>,
+    pub one: Option<T>,
+    pub two: Option<T>,
+    pub three: Option<T>,
+    pub four: Option<T>,
+    pub five: Option<T>,
 }
 
 impl<T> HexNeighbors<T> {

--- a/src/helpers/hex_grid/offset.rs
+++ b/src/helpers/hex_grid/offset.rs
@@ -14,6 +14,7 @@ pub struct RowOddPos {
 
 impl RowOddPos {
     /// Returns the position of this tile's center, in world space.
+    #[inline]
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
         let axial_pos = AxialPos::from(*self);
         axial_pos.center_in_world_row(grid_size)
@@ -21,6 +22,7 @@ impl RowOddPos {
 
     /// Returns the offset to the corner of a hex tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_offset_in_world(
         corner_direction: HexRowDirection,
         grid_size: &TilemapGridSize,
@@ -30,6 +32,7 @@ impl RowOddPos {
 
     /// Returns the position of the corner of a hex tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_in_world(
         &self,
         corner_direction: HexRowDirection,
@@ -40,6 +43,7 @@ impl RowOddPos {
     }
 
     /// Returns the tile containing the given world position.
+    #[inline]
     pub fn from_world_pos(world_pos: &Vec2, grid_size: &TilemapGridSize) -> Self {
         let axial_pos = AxialPos::from_world_pos_row(world_pos, grid_size);
         RowOddPos::from(axial_pos)
@@ -49,6 +53,7 @@ impl RowOddPos {
     ///
     /// Returns `None` if either one of `q` or `r` is negative, or lies out of the bounds of
     /// `map_size`.
+    #[inline]
     pub fn as_tile_pos_given_map_size(&self, map_size: &TilemapSize) -> Option<TilePos> {
         TilePos::from_i32_pair(self.q, self.r, map_size)
     }
@@ -56,6 +61,7 @@ impl RowOddPos {
     /// Convert naively into a [`TilePos`].
     ///
     /// `q` becomes `x` and `r` becomes `y`.
+    #[inline]
     pub fn as_tile_pos_unchecked(&self) -> TilePos {
         TilePos {
             x: self.q as u32,
@@ -64,17 +70,20 @@ impl RowOddPos {
     }
 
     /// Get the tile offset from `self` in the given [`HexDirection`].
+    #[inline]
     pub fn offset(&self, direction: HexDirection) -> Self {
         Self::from(AxialPos::from(*self).offset(direction))
     }
 
     /// Get the tile offset from `self` in the given [`HexRowDirection`].
+    #[inline]
     pub fn offset_compass(&self, direction: HexColDirection) -> Self {
         Self::from(AxialPos::from(*self).offset(direction.into()))
     }
 }
 
 impl From<&TilePos> for RowOddPos {
+    #[inline]
     fn from(tile_pos: &TilePos) -> Self {
         RowOddPos {
             q: tile_pos.x as i32,
@@ -91,6 +100,7 @@ pub struct RowEvenPos {
 
 impl RowEvenPos {
     /// Returns the position of this tile's center, in world space.
+    #[inline]
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
         let axial_pos = AxialPos::from(*self);
         axial_pos.center_in_world_row(grid_size)
@@ -98,6 +108,7 @@ impl RowEvenPos {
 
     /// Returns the offset to the corner of a hex tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_offset_in_world(
         corner_direction: HexRowDirection,
         grid_size: &TilemapGridSize,
@@ -107,6 +118,7 @@ impl RowEvenPos {
 
     /// Returns the position of the corner of a hex tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_in_world(
         &self,
         corner_direction: HexRowDirection,
@@ -117,6 +129,7 @@ impl RowEvenPos {
     }
 
     /// Returns the tile containing the given world position.
+    #[inline]
     pub fn from_world_pos(world_pos: &Vec2, grid_size: &TilemapGridSize) -> Self {
         let axial_pos = AxialPos::from_world_pos_row(world_pos, grid_size);
         RowEvenPos::from(axial_pos)
@@ -126,6 +139,7 @@ impl RowEvenPos {
     ///
     /// Returns `None` if either one of `q` or `r` is negative, or lies out of the bounds of
     /// `map_size`.
+    #[inline]
     pub fn as_tile_pos_given_map_size(&self, map_size: &TilemapSize) -> Option<TilePos> {
         TilePos::from_i32_pair(self.q, self.r, map_size)
     }
@@ -133,6 +147,7 @@ impl RowEvenPos {
     /// Convert naively into a [`TilePos`].
     ///
     /// `q` becomes `x` and `r` becomes `y`.
+    #[inline]
     pub fn as_tile_pos_unchecked(&self) -> TilePos {
         TilePos {
             x: self.q as u32,
@@ -141,17 +156,20 @@ impl RowEvenPos {
     }
 
     /// Get the tile offset from `self` in the given [`HexDirection`].
+    #[inline]
     pub fn offset(&self, direction: HexDirection) -> Self {
         Self::from(AxialPos::from(*self).offset(direction))
     }
 
     /// Get the tile offset from `self` in the given [`HexRowDirection`].
+    #[inline]
     pub fn offset_compass(&self, direction: HexColDirection) -> Self {
         Self::from(AxialPos::from(*self).offset(direction.into()))
     }
 }
 
 impl From<&TilePos> for RowEvenPos {
+    #[inline]
     fn from(tile_pos: &TilePos) -> Self {
         RowEvenPos {
             q: tile_pos.x as i32,
@@ -168,6 +186,7 @@ pub struct ColOddPos {
 
 impl ColOddPos {
     /// Returns the position of this tile's center, in world space.
+    #[inline]
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
         let axial_pos = AxialPos::from(*self);
         axial_pos.center_in_world_col(grid_size)
@@ -175,6 +194,7 @@ impl ColOddPos {
 
     /// Returns the offset to the corner of a hex tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_offset_in_world(
         corner_direction: HexColDirection,
         grid_size: &TilemapGridSize,
@@ -184,6 +204,7 @@ impl ColOddPos {
 
     /// Returns the position of the corner of a hex tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_in_world(
         &self,
         corner_direction: HexColDirection,
@@ -194,6 +215,7 @@ impl ColOddPos {
     }
 
     /// Returns the tile containing the given world position.
+    #[inline]
     pub fn from_world_pos(world_pos: &Vec2, grid_size: &TilemapGridSize) -> Self {
         let axial_pos = AxialPos::from_world_pos_col(world_pos, grid_size);
         ColOddPos::from(axial_pos)
@@ -203,6 +225,7 @@ impl ColOddPos {
     ///
     /// Returns `None` if either one of `q` or `r` is negative, or lies out of the bounds of
     /// `map_size`.
+    #[inline]
     pub fn as_tile_pos_given_map_size(&self, map_size: &TilemapSize) -> Option<TilePos> {
         TilePos::from_i32_pair(self.q, self.r, map_size)
     }
@@ -210,6 +233,7 @@ impl ColOddPos {
     /// Convert naively into a [`TilePos`].
     ///
     /// `q` becomes `x` and `r` becomes `y`.
+    #[inline]
     pub fn as_tile_pos_unchecked(&self) -> TilePos {
         TilePos {
             x: self.q as u32,
@@ -218,17 +242,20 @@ impl ColOddPos {
     }
 
     /// Get the tile offset from `self` in the given [`HexDirection`].
+    #[inline]
     pub fn offset(&self, direction: HexDirection) -> Self {
         Self::from(AxialPos::from(*self).offset(direction))
     }
 
     /// Get the tile offset from `self` in the given [`HexColDirection`].
+    #[inline]
     pub fn offset_compass(&self, direction: HexRowDirection) -> Self {
         Self::from(AxialPos::from(*self).offset(direction.into()))
     }
 }
 
 impl From<&TilePos> for ColOddPos {
+    #[inline]
     fn from(tile_pos: &TilePos) -> Self {
         ColOddPos {
             q: tile_pos.x as i32,
@@ -245,6 +272,7 @@ pub struct ColEvenPos {
 
 impl ColEvenPos {
     /// Returns the position of this tile's center, in world space.
+    #[inline]
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
         let axial_pos = AxialPos::from(*self);
         axial_pos.center_in_world_col(grid_size)
@@ -252,6 +280,7 @@ impl ColEvenPos {
 
     /// Returns the offset to the corner of a hex tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_offset_in_world(
         corner_direction: HexColDirection,
         grid_size: &TilemapGridSize,
@@ -261,6 +290,7 @@ impl ColEvenPos {
 
     /// Returns the position of the corner of a hex tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_in_world(
         &self,
         corner_direction: HexColDirection,
@@ -271,6 +301,7 @@ impl ColEvenPos {
     }
 
     /// Returns the tile containing the given world position.
+    #[inline]
     pub fn from_world_pos(world_pos: &Vec2, grid_size: &TilemapGridSize) -> Self {
         let axial_pos = AxialPos::from_world_pos_col(world_pos, grid_size);
         ColEvenPos::from(axial_pos)
@@ -280,6 +311,7 @@ impl ColEvenPos {
     ///
     /// Returns `None` if either one of `q` or `r` is negative, or lies out of the bounds of
     /// `map_size`.
+    #[inline]
     pub fn as_tile_pos_given_map_size(&self, map_size: &TilemapSize) -> Option<TilePos> {
         TilePos::from_i32_pair(self.q, self.r, map_size)
     }
@@ -287,6 +319,7 @@ impl ColEvenPos {
     /// Convert naively into a [`TilePos`].
     ///
     /// `q` becomes `x` and `r` becomes `y`.
+    #[inline]
     pub fn as_tile_pos_unchecked(&self) -> TilePos {
         TilePos {
             x: self.q as u32,
@@ -295,17 +328,20 @@ impl ColEvenPos {
     }
 
     /// Get the tile offset from `self` in the given [`HexDirection`].
+    #[inline]
     pub fn offset(&self, direction: HexDirection) -> Self {
         Self::from(AxialPos::from(*self).offset(direction))
     }
 
     /// Get the tile offset from `self` in the given [`HexColDirection`].
+    #[inline]
     pub fn offset_compass(&self, direction: HexRowDirection) -> Self {
         Self::from(AxialPos::from(*self).offset(direction.into()))
     }
 }
 
 impl From<&TilePos> for ColEvenPos {
+    #[inline]
     fn from(tile_pos: &TilePos) -> Self {
         ColEvenPos {
             q: tile_pos.x as i32,

--- a/src/helpers/square_grid/diamond.rs
+++ b/src/helpers/square_grid/diamond.rs
@@ -74,6 +74,7 @@ pub const DIAMOND_BASIS: Mat2 = Mat2::from_cols(Vec2::new(0.5, -0.5), Vec2::new(
 pub const INV_DIAMOND_BASIS: Mat2 = Mat2::from_cols(Vec2::new(1.0, 1.0), Vec2::new(-1.0, 1.0));
 
 impl From<TilePos> for DiamondPos {
+    #[inline]
     fn from(tile_pos: TilePos) -> Self {
         let TilePos { x, y } = tile_pos;
         DiamondPos {
@@ -84,12 +85,14 @@ impl From<TilePos> for DiamondPos {
 }
 
 impl From<&TilePos> for DiamondPos {
+    #[inline]
     fn from(tile_pos: &TilePos) -> Self {
         DiamondPos::from(*tile_pos)
     }
 }
 
 impl From<StaggeredPos> for DiamondPos {
+    #[inline]
     fn from(staggered_pos: StaggeredPos) -> Self {
         let StaggeredPos { x, y } = staggered_pos;
         DiamondPos { x, y: y + x }
@@ -97,12 +100,14 @@ impl From<StaggeredPos> for DiamondPos {
 }
 
 impl From<&StaggeredPos> for DiamondPos {
+    #[inline]
     fn from(staggered_pos: &StaggeredPos) -> Self {
         DiamondPos::from(*staggered_pos)
     }
 }
 
 impl From<SquarePos> for DiamondPos {
+    #[inline]
     fn from(square_pos: SquarePos) -> Self {
         let SquarePos { x, y } = square_pos;
         DiamondPos { x, y }
@@ -110,6 +115,7 @@ impl From<SquarePos> for DiamondPos {
 }
 
 impl From<&SquarePos> for DiamondPos {
+    #[inline]
     fn from(square_pos: &SquarePos) -> Self {
         DiamondPos::from(*square_pos)
     }
@@ -121,18 +127,21 @@ impl DiamondPos {
     ///
     /// This is a helper function for [`center_in_world`], [`corner_offset_in_world`] and
     /// [`corner_in_world`].
+    #[inline]
     pub fn project(pos: Vec2, grid_size: &TilemapGridSize) -> Vec2 {
         let unscaled_pos = DIAMOND_BASIS * pos;
         Vec2::new(grid_size.x * unscaled_pos.x, grid_size.y * unscaled_pos.y)
     }
 
     /// Returns the position of this tile's center, in world space.
+    #[inline]
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
         Self::project(Vec2::new(self.x as f32, self.y as f32), grid_size)
     }
 
     /// Returns the offset to the corner of a tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_offset_in_world(
         corner_direction: SquareDirection,
         grid_size: &TilemapGridSize,
@@ -144,6 +153,7 @@ impl DiamondPos {
 
     /// Returns the coordinate of the corner of a tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_in_world(
         &self,
         corner_direction: SquareDirection,
@@ -158,6 +168,7 @@ impl DiamondPos {
     }
 
     /// Returns the tile containing the given world position.
+    #[inline]
     pub fn from_world_pos(world_pos: &Vec2, grid_size: &TilemapGridSize) -> DiamondPos {
         let normalized_world_pos = Vec2::new(world_pos.x / grid_size.x, world_pos.y / grid_size.y);
         let Vec2 { x, y } = INV_DIAMOND_BASIS * normalized_world_pos;
@@ -171,12 +182,29 @@ impl DiamondPos {
     ///
     /// Returns `None` if either one of `self.x` or `self.y` is negative, or lies outside of the
     /// bounds of `map_size`.
+    #[inline]
     pub fn as_tile_pos(&self, map_size: &TilemapSize) -> Option<TilePos> {
         TilePos::from_i32_pair(self.x, self.y, map_size)
     }
 
     /// Calculate offset in the given direction.
+    #[inline]
     pub fn offset(&self, direction: &SquareDirection) -> DiamondPos {
         DiamondPos::from(SquarePos::from(self) + SQUARE_OFFSETS[*direction as usize])
+    }
+}
+
+impl TilePos {
+    /// Get the neighbor lying in the specified direction from this position, if it  fits on the map
+    /// and assuming that this is a map using the isometric diamond coordinate system.
+    #[inline]
+    pub fn diamond_offset(
+        &self,
+        direction: &SquareDirection,
+        map_size: &TilemapSize,
+    ) -> Option<TilePos> {
+        DiamondPos::from(self)
+            .offset(direction)
+            .as_tile_pos(map_size)
     }
 }

--- a/src/helpers/square_grid/mod.rs
+++ b/src/helpers/square_grid/mod.rs
@@ -58,6 +58,7 @@ impl Mul<SquarePos> for i32 {
 }
 
 impl From<&TilePos> for SquarePos {
+    #[inline]
     fn from(tile_pos: &TilePos) -> Self {
         Self {
             x: tile_pos.x as i32,
@@ -67,6 +68,7 @@ impl From<&TilePos> for SquarePos {
 }
 
 impl From<&DiamondPos> for SquarePos {
+    #[inline]
     fn from(diamond_pos: &DiamondPos) -> Self {
         let DiamondPos { x, y } = *diamond_pos;
         SquarePos { x, y }
@@ -74,6 +76,7 @@ impl From<&DiamondPos> for SquarePos {
 }
 
 impl From<DiamondPos> for SquarePos {
+    #[inline]
     fn from(diamond_pos: DiamondPos) -> Self {
         let DiamondPos { x, y } = diamond_pos;
         SquarePos { x, y }
@@ -81,6 +84,7 @@ impl From<DiamondPos> for SquarePos {
 }
 
 impl From<&StaggeredPos> for SquarePos {
+    #[inline]
     fn from(staggered_pos: &StaggeredPos) -> Self {
         let StaggeredPos { x, y } = *staggered_pos;
         SquarePos { x, y: y + x }
@@ -88,6 +92,7 @@ impl From<&StaggeredPos> for SquarePos {
 }
 
 impl From<StaggeredPos> for SquarePos {
+    #[inline]
     fn from(staggered_pos: StaggeredPos) -> Self {
         let StaggeredPos { x, y } = staggered_pos;
         SquarePos { x, y: y + x }
@@ -100,17 +105,20 @@ impl SquarePos {
     ///
     /// This is a helper function for [`center_in_world`], [`corner_offset_in_world`] and
     /// [`corner_in_world`].
+    #[inline]
     pub fn project(pos: Vec2, grid_size: &TilemapGridSize) -> Vec2 {
         Vec2::new(grid_size.x * pos.x, grid_size.y * pos.y)
     }
 
     /// Returns the position of this tile's center, in world space.
+    #[inline]
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
         Self::project(Vec2::new(self.x as f32, self.y as f32), grid_size)
     }
 
     /// Returns the offset to the corner of a tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_offset_in_world(
         corner_direction: SquareDirection,
         grid_size: &TilemapGridSize,
@@ -122,6 +130,7 @@ impl SquarePos {
 
     /// Returns the coordinate of the corner of a tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_in_world(
         &self,
         corner_direction: SquareDirection,
@@ -136,6 +145,7 @@ impl SquarePos {
     }
 
     /// Returns the tile containing the given world position.
+    #[inline]
     pub fn from_world_pos(world_pos: &Vec2, grid_size: &TilemapGridSize) -> SquarePos {
         let normalized_world_pos = Vec2::new(world_pos.x / grid_size.x, world_pos.y / grid_size.y);
         let Vec2 { x, y } = normalized_world_pos;
@@ -149,12 +159,29 @@ impl SquarePos {
     ///
     /// Returns `None` if either one of `self.x` or `self.y` is negative, or lies outside of the
     /// bounds of `map_size`.
+    #[inline]
     pub fn as_tile_pos(&self, map_size: &TilemapSize) -> Option<TilePos> {
         TilePos::from_i32_pair(self.x, self.y, map_size)
     }
 
     /// Calculate offset in the given direction.
+    #[inline]
     pub fn offset(&self, direction: &SquareDirection) -> SquarePos {
         *self + SQUARE_OFFSETS[*direction as usize]
+    }
+}
+
+impl TilePos {
+    /// Get the neighbor lying in the specified direction from this position, if it  fits on the map
+    /// and assuming that this is a map using the standard (non-isometric) square coordinate system
+    #[inline]
+    pub fn square_offset(
+        &self,
+        direction: &SquareDirection,
+        map_size: &TilemapSize,
+    ) -> Option<TilePos> {
+        SquarePos::from(self)
+            .offset(direction)
+            .as_tile_pos(map_size)
     }
 }

--- a/src/helpers/square_grid/neighbors.rs
+++ b/src/helpers/square_grid/neighbors.rs
@@ -159,14 +159,14 @@ impl Sub<i32> for SquareDirection {
 /// Stores some data `T` associated with each neighboring grid cell, if present.
 #[derive(Debug, Default)]
 pub struct Neighbors<T> {
-    east: Option<T>,
-    north_east: Option<T>,
-    north: Option<T>,
-    north_west: Option<T>,
-    west: Option<T>,
-    south_west: Option<T>,
-    south: Option<T>,
-    south_east: Option<T>,
+    pub east: Option<T>,
+    pub north_east: Option<T>,
+    pub north: Option<T>,
+    pub north_west: Option<T>,
+    pub west: Option<T>,
+    pub south_west: Option<T>,
+    pub south: Option<T>,
+    pub south_east: Option<T>,
 }
 
 impl<T> Neighbors<T> {

--- a/src/helpers/square_grid/staggered.rs
+++ b/src/helpers/square_grid/staggered.rs
@@ -90,12 +90,14 @@ impl Mul<StaggeredPos> for i32 {
 
 impl StaggeredPos {
     /// Returns the position of this tile's center, in world space.
+    #[inline]
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
         DiamondPos::from(self).center_in_world(grid_size)
     }
 
     /// Returns the offset to the corner of a tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_offset_in_world(
         corner_direction: SquareDirection,
         grid_size: &TilemapGridSize,
@@ -105,6 +107,7 @@ impl StaggeredPos {
 
     /// Returns the coordinate of the corner of a tile in the specified `corner_direction`,
     /// in world space
+    #[inline]
     pub fn corner_in_world(
         &self,
         corner_direction: SquareDirection,
@@ -121,6 +124,7 @@ impl StaggeredPos {
     }
 
     /// Returns the tile containing the given world position.
+    #[inline]
     pub fn from_world_pos(world_pos: &Vec2, grid_size: &TilemapGridSize) -> StaggeredPos {
         DiamondPos::from_world_pos(world_pos, grid_size).into()
     }
@@ -129,12 +133,29 @@ impl StaggeredPos {
     ///
     /// Returns `None` if either one of `self.x` or `self.y` is negative, or lies outside of the
     /// bounds of `map_size`.
+    #[inline]
     pub fn as_tile_pos(&self, map_size: &TilemapSize) -> Option<TilePos> {
         TilePos::from_i32_pair(self.x, self.y, map_size)
     }
 
     /// Calculate offset in the given direction.
+    #[inline]
     pub fn offset(&self, direction: &SquareDirection) -> StaggeredPos {
         StaggeredPos::from(SquarePos::from(self) + SQUARE_OFFSETS[*direction as usize])
+    }
+}
+
+impl TilePos {
+    /// Get the neighbor lying in the specified direction from this position, if it  fits on the map
+    /// and assuming that this is a map that is using the isometric staggered coordinate system.
+    #[inline]
+    pub fn staggered_offset(
+        &self,
+        direction: &SquareDirection,
+        map_size: &TilemapSize,
+    ) -> Option<TilePos> {
+        StaggeredPos::from(self)
+            .offset(direction)
+            .as_tile_pos(map_size)
     }
 }


### PR DESCRIPTION
* #[inline] all coordinate conversion and neighbor helpers

* make neighbor fields public, so that the structs can be created manually by the user