### PR TITLE
Remove unused section from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,6 @@ features = [
     "bevy_sprite",
 ]
 
-[target.wasm32-unknown-unknown]
-runner = "wasm-server-runner"
-
 [[example]]
 name = "ldtk"
 path = "examples/ldtk/ldtk_usage.rs"

--- a/README.md
+++ b/README.md
@@ -72,9 +72,12 @@ cargo run --release --example basic
 ```
 
 ### Running examples on web!
+
+This can be made simple with [wasm-server-runner](https://github.com/jakobhellermann/wasm-server-runner).
+
+After that's installed and configured, run:
 ```
-cargo build --target wasm32-unknown-unknown --example animation --release --features atlas
-wasm-server-runner .\target\wasm32-unknown-unknown\release\examples\animation.wasm
+cargo run --target wasm32-unknown-unknown --example animation --release --features atlas
 ```
 
 ## Known Issues


### PR DESCRIPTION
Fixes this warning seen when running any example
```
warning: unused manifest key: target.wasm32-unknown-unknown.runner
```

As noted here: https://github.com/jakobhellermann/wasm-server-runner#step-2 this only works in an individual's cargo config.