### PR TITLE
Fix broken rendering of tilemaps with padding in atlas mode

### DIFF
--- a/src/render/shaders/tilemap_vertex.wgsl
+++ b/src/render/shaders/tilemap_vertex.wgsl
@@ -57,12 +57,11 @@ fn vertex(vertex_input: VertexInput) -> VertexOutput {
 
     var texture_index: u32 = u32(current_animation_frame);
 
+    #ifdef ATLAS
     var columns: u32 = u32((tilemap_data.texture_size.x - tilemap_data.spacing.x) / (tilemap_data.tile_size.x + tilemap_data.spacing.x));
-
     var sprite_sheet_x: f32 = tilemap_data.spacing.x + floor(f32(texture_index % columns)) * (tilemap_data.tile_size.x + tilemap_data.spacing.x);
     var sprite_sheet_y: f32 = tilemap_data.spacing.y + floor(f32(texture_index / columns)) * (tilemap_data.tile_size.y + tilemap_data.spacing.y);
 
-    #ifdef ATLAS
     var start_u: f32 = sprite_sheet_x / tilemap_data.texture_size.x;
     var end_u: f32 = (sprite_sheet_x + tilemap_data.tile_size.x) / tilemap_data.texture_size.x;
     var start_v: f32 = sprite_sheet_y / tilemap_data.texture_size.y;

--- a/src/render/shaders/tilemap_vertex.wgsl
+++ b/src/render/shaders/tilemap_vertex.wgsl
@@ -57,10 +57,10 @@ fn vertex(vertex_input: VertexInput) -> VertexOutput {
 
     var texture_index: u32 = u32(current_animation_frame);
 
-    var columns: u32 = u32((tilemap_data.texture_size.x + tilemap_data.spacing.x) / (tilemap_data.tile_size.x + tilemap_data.spacing.x));
+    var columns: u32 = u32((tilemap_data.texture_size.x - tilemap_data.spacing.x) / (tilemap_data.tile_size.x + tilemap_data.spacing.x));
 
-    var sprite_sheet_x: f32 = floor(f32(texture_index % columns)) * (tilemap_data.tile_size.x + tilemap_data.spacing.x);
-    var sprite_sheet_y: f32 = floor(f32(texture_index / columns)) * (tilemap_data.tile_size.y + tilemap_data.spacing.y);
+    var sprite_sheet_x: f32 = tilemap_data.spacing.x + floor(f32(texture_index % columns)) * (tilemap_data.tile_size.x + tilemap_data.spacing.x);
+    var sprite_sheet_y: f32 = tilemap_data.spacing.y + floor(f32(texture_index / columns)) * (tilemap_data.tile_size.y + tilemap_data.spacing.y);
 
     #ifdef ATLAS
     var start_u: f32 = sprite_sheet_x / tilemap_data.texture_size.x;

--- a/src/render/shaders/tilemap_vertex.wgsl
+++ b/src/render/shaders/tilemap_vertex.wgsl
@@ -58,6 +58,8 @@ fn vertex(vertex_input: VertexInput) -> VertexOutput {
     var texture_index: u32 = u32(current_animation_frame);
 
     #ifdef ATLAS
+    // Get the top-left corner of the current frame in the texture, accounting for padding around the whole texture
+    // as well as spacing between the tiles.
     var columns: u32 = u32((tilemap_data.texture_size.x - tilemap_data.spacing.x) / (tilemap_data.tile_size.x + tilemap_data.spacing.x));
     var sprite_sheet_x: f32 = tilemap_data.spacing.x + floor(f32(texture_index % columns)) * (tilemap_data.tile_size.x + tilemap_data.spacing.x);
     var sprite_sheet_y: f32 = tilemap_data.spacing.y + floor(f32(texture_index / columns)) * (tilemap_data.tile_size.y + tilemap_data.spacing.y);


### PR DESCRIPTION
Fixes #352 

`var columns` was mistakenly adding rather than subtracting one side of the spacing, potentially causing the wrong tiles to be displayed. This bug was not visible in the spacing example. However, this would have produced the wrong result when spacing was greater than or equal to tile size.

`sprite_sheet_x` and `sprite_sheet_y` were not accounting for the what bevy calls the "offset" -- the spacing in the left gutter of the texture.

Before:
`cargo run --example spacing --features=atlas`
<img width="1270" alt="image" src="https://user-images.githubusercontent.com/200550/204659490-4e0f556d-0a89-4567-afe9-dd2b10d63430.png">

After
`cargo run --example spacing --features=atlas`
<img width="1270" alt="image" src="https://user-images.githubusercontent.com/200550/204659610-5cf91673-7a7b-4d4d-a1e9-3db126ec7bc3.png">

Note: the spacing example is intentionally displaying an incorrectly configured tilemap in blue.
