### PR TITLE
Fix incorrect tile UVs when using atlas feature on AMD hardware

### DIFF
--- a/src/render/shaders/tilemap_vertex.wgsl
+++ b/src/render/shaders/tilemap_vertex.wgsl
@@ -60,7 +60,7 @@ fn vertex(vertex_input: VertexInput) -> VertexOutput {
     #ifdef ATLAS
     // Get the top-left corner of the current frame in the texture, accounting for padding around the whole texture
     // as well as spacing between the tiles.
-    var columns: u32 = u32((tilemap_data.texture_size.x - tilemap_data.spacing.x) / (tilemap_data.tile_size.x + tilemap_data.spacing.x));
+    var columns: u32 = u32(round((tilemap_data.texture_size.x - tilemap_data.spacing.x) / (tilemap_data.tile_size.x + tilemap_data.spacing.x)));
     var sprite_sheet_x: f32 = tilemap_data.spacing.x + floor(f32(texture_index % columns)) * (tilemap_data.tile_size.x + tilemap_data.spacing.x);
     var sprite_sheet_y: f32 = tilemap_data.spacing.y + floor(f32(texture_index / columns)) * (tilemap_data.tile_size.y + tilemap_data.spacing.y);
 


### PR DESCRIPTION
Fixes an issue reported by @odecay on discord.

This is specific to AMD hardware and the issue and fix were reproduced by @odecay and @bzm3r. I am unable to reproduce on any of my non-AMD HW.

Here's a changeset on their fork that reproduces the issue:
https://github.com/StarArawn/bevy_ecs_tilemap/compare/main...odecay:bevy_ecs_tilemap:main

That example should show something like this:
![image](https://user-images.githubusercontent.com/200550/208279993-c230ecbf-85ce-42dd-946c-c0b629c3da88.png)
But shows this instead:
![image](https://user-images.githubusercontent.com/200550/208279984-56e33d47-5459-4c98-a183-dd8271496359.png)

It seems that there's some sort of floating point imprecision thing going on where `var columns` ends up as `2` rather than the correct `3` after being cast as `u32` / implicitly `floor`ed. This messes up the rest of the UV calculations.

It is possible to induce this same visual result on hardware that doesn't exhibit this bug by subtracting 1 from `var columns`.
