### PR TITLE
Use let where possible in shaders

### DIFF
--- a/src/render/shaders/column_even_hex.wgsl
+++ b/src/render/shaders/column_even_hex.wgsl
@@ -4,7 +4,6 @@
 
 let SQRT_3: f32 = 1.7320508;
 let HALF_SQRT_3: f32 = 0.8660254;
-
 let COL_BASIS_X: vec2<f32> = vec2<f32>(HALF_SQRT_3, 0.5);
 let COL_BASIS_Y: vec2<f32> = vec2<f32>(0.0, 1.0);
 
@@ -18,13 +17,14 @@ fn col_even_to_axial(offset_pos: vec2<f32>) -> vec2<f32> {
     let delta: f32 = ceil(offset_pos.x / 2.0);
     return vec2<f32>(offset_pos.x, offset_pos.y - delta);
 }
+
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> MeshOutput {
     var out: MeshOutput;
 
-    var axial_pos = col_even_to_axial(vertex_position.xy);
-    var center = hex_col_tile_pos_to_world_pos(axial_pos, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
-    var bot_left = center - 0.5 * tilemap_data.tile_size;
-    var top_right = bot_left + tilemap_data.tile_size;
+    let axial_pos = col_even_to_axial(vertex_position.xy);
+    let center = hex_col_tile_pos_to_world_pos(axial_pos, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
+    let bot_left = center - 0.5 * tilemap_data.tile_size;
+    let top_right = bot_left + tilemap_data.tile_size;
 
     var positions = array<vec2<f32>, 4>(
         bot_left,

--- a/src/render/shaders/column_hex.wgsl
+++ b/src/render/shaders/column_hex.wgsl
@@ -13,13 +13,12 @@ fn hex_col_tile_pos_to_world_pos(pos: vec2<f32>, grid_width: f32, grid_height: f
     return vec2<f32>(COL_BASIS_X.x * grid_width * unscaled_pos.x, grid_height * unscaled_pos.y);
 }
 
-
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> MeshOutput {
     var out: MeshOutput;
 
-    var center = hex_col_tile_pos_to_world_pos(vertex_position.xy, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
-    var bot_left = center - 0.5 * tilemap_data.tile_size;
-    var top_right = bot_left + tilemap_data.tile_size;
+    let center = hex_col_tile_pos_to_world_pos(vertex_position.xy, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
+    let bot_left = center - 0.5 * tilemap_data.tile_size;
+    let top_right = bot_left + tilemap_data.tile_size;
 
     var positions = array<vec2<f32>, 4>(
         bot_left,

--- a/src/render/shaders/column_odd_hex.wgsl
+++ b/src/render/shaders/column_odd_hex.wgsl
@@ -21,10 +21,10 @@ fn col_even_to_axial(offset_pos: vec2<f32>) -> vec2<f32> {
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> MeshOutput {
     var out: MeshOutput;
 
-    var axial_pos = col_even_to_axial(vertex_position.xy);
-    var center = hex_col_tile_pos_to_world_pos(axial_pos, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
-    var bot_left = center - 0.5 * tilemap_data.tile_size;
-    var top_right = bot_left + tilemap_data.tile_size;
+    let axial_pos = col_even_to_axial(vertex_position.xy);
+    let center = hex_col_tile_pos_to_world_pos(axial_pos, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
+    let bot_left = center - 0.5 * tilemap_data.tile_size;
+    let top_right = bot_left + tilemap_data.tile_size;
 
     var positions = array<vec2<f32>, 4>(
         bot_left,

--- a/src/render/shaders/diamond_iso.wgsl
+++ b/src/render/shaders/diamond_iso.wgsl
@@ -14,9 +14,9 @@ fn diamond_tile_pos_to_world_pos(pos: vec2<f32>, grid_width: f32, grid_height: f
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> MeshOutput {
     var out: MeshOutput;
 
-    var center = diamond_tile_pos_to_world_pos(vertex_position.xy, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
-    var bot_left = center - 0.5 * tilemap_data.tile_size;
-    var top_right = bot_left + tilemap_data.tile_size;
+    let center = diamond_tile_pos_to_world_pos(vertex_position.xy, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
+    let bot_left = center - 0.5 * tilemap_data.tile_size;
+    let top_right = bot_left + tilemap_data.tile_size;
 
     var positions = array<vec2<f32>, 4>(
         bot_left,

--- a/src/render/shaders/row_even_hex.wgsl
+++ b/src/render/shaders/row_even_hex.wgsl
@@ -21,10 +21,10 @@ fn row_even_to_axial(offset_pos: vec2<f32>) -> vec2<f32> {
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> MeshOutput {
     var out: MeshOutput;
 
-    var axial_pos = row_even_to_axial(vertex_position.xy);
-    var center = hex_row_tile_pos_to_world_pos(axial_pos, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
-    var bot_left = center - 0.5 * tilemap_data.tile_size;
-    var top_right = bot_left + tilemap_data.tile_size;
+    let axial_pos = row_even_to_axial(vertex_position.xy);
+    let center = hex_row_tile_pos_to_world_pos(axial_pos, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
+    let bot_left = center - 0.5 * tilemap_data.tile_size;
+    let top_right = bot_left + tilemap_data.tile_size;
 
     var positions = array<vec2<f32>, 4>(
         bot_left,

--- a/src/render/shaders/row_hex.wgsl
+++ b/src/render/shaders/row_hex.wgsl
@@ -16,9 +16,9 @@ fn hex_row_tile_pos_to_world_pos(pos: vec2<f32>, grid_width: f32, grid_height: f
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> MeshOutput {
     var out: MeshOutput;
 
-    var center = hex_row_tile_pos_to_world_pos(vertex_position.xy, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
-    var bot_left = center - 0.5 * tilemap_data.tile_size;
-    var top_right = bot_left + tilemap_data.tile_size;
+    let center = hex_row_tile_pos_to_world_pos(vertex_position.xy, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
+    let bot_left = center - 0.5 * tilemap_data.tile_size;
+    let top_right = bot_left + tilemap_data.tile_size;
 
     var positions = array<vec2<f32>, 4>(
         bot_left,

--- a/src/render/shaders/row_odd_hex.wgsl
+++ b/src/render/shaders/row_odd_hex.wgsl
@@ -21,10 +21,10 @@ fn row_odd_to_axial(offset_pos: vec2<f32>) -> vec2<f32> {
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> MeshOutput {
     var out: MeshOutput;
 
-    var axial_pos = row_odd_to_axial(vertex_position.xy);
-    var center = hex_row_tile_pos_to_world_pos(axial_pos, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
-    var bot_left = center - 0.5 * tilemap_data.tile_size;
-    var top_right = bot_left + tilemap_data.tile_size;
+    let axial_pos = row_odd_to_axial(vertex_position.xy);
+    let center = hex_row_tile_pos_to_world_pos(axial_pos, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
+    let bot_left = center - 0.5 * tilemap_data.tile_size;
+    let top_right = bot_left + tilemap_data.tile_size;
 
     var positions = array<vec2<f32>, 4>(
         bot_left,

--- a/src/render/shaders/square.wgsl
+++ b/src/render/shaders/square.wgsl
@@ -5,9 +5,9 @@
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> MeshOutput {
     var out: MeshOutput;
 
-    var center = vertex_position.xy * tilemap_data.grid_size;
-    var bot_left = center - 0.5 * tilemap_data.tile_size;
-    var top_right = bot_left + tilemap_data.tile_size;
+    let center = vertex_position.xy * tilemap_data.grid_size;
+    let bot_left = center - 0.5 * tilemap_data.tile_size;
+    let top_right = bot_left + tilemap_data.tile_size;
 
     var positions = array<vec2<f32>, 4>(
         bot_left,

--- a/src/render/shaders/staggered_iso.wgsl
+++ b/src/render/shaders/staggered_iso.wgsl
@@ -19,9 +19,9 @@ fn staggered_tile_pos_to_world_pos(pos: vec2<f32>, grid_width: f32, grid_height:
 fn get_mesh(v_index: u32, vertex_position: vec3<f32>) -> MeshOutput {
     var out: MeshOutput;
 
-    var center = staggered_tile_pos_to_world_pos(vertex_position.xy, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
-    var bot_left = center - 0.5 * tilemap_data.tile_size;
-    var top_right = bot_left + tilemap_data.tile_size;
+    let center = staggered_tile_pos_to_world_pos(vertex_position.xy, tilemap_data.grid_size.x, tilemap_data.grid_size.y);
+    let bot_left = center - 0.5 * tilemap_data.tile_size;
+    let top_right = bot_left + tilemap_data.tile_size;
 
     var positions = array<vec2<f32>, 4>(
         bot_left,

--- a/src/render/shaders/tilemap_fragment.wgsl
+++ b/src/render/shaders/tilemap_fragment.wgsl
@@ -8,13 +8,13 @@ struct VertexOutput {
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     #ifdef ATLAS
-    var half_texture_pixel_size_u = 0.5 / tilemap_data.texture_size.x;
-    var half_texture_pixel_size_v = 0.5 / tilemap_data.texture_size.y;
+    let half_texture_pixel_size_u = 0.5 / tilemap_data.texture_size.x;
+    let half_texture_pixel_size_v = 0.5 / tilemap_data.texture_size.y;
     let half_tile_pixel_size_u = 0.5 / tilemap_data.tile_size.x;
     let half_tile_pixel_size_v = 0.5 / tilemap_data.tile_size.y;
 
-        // Offset the UV 1/2 pixel from the sides of the tile, so that the sampler doesn't bleed onto
-        // adjacent tiles at the edges.
+    // Offset the UV 1/2 pixel from the sides of the tile, so that the sampler doesn't bleed onto
+    // adjacent tiles at the edges.
     var uv_offset: vec2<f32> = vec2<f32>(0.0, 0.0);
     if (in.uv.z < half_tile_pixel_size_u) {
         uv_offset.x = half_texture_pixel_size_u;
@@ -27,15 +27,15 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
         uv_offset.y = - half_texture_pixel_size_v;
     }
 
-    var color = textureSample(sprite_texture, sprite_sampler, in.uv.xy + uv_offset) * in.color;
+    let color = textureSample(sprite_texture, sprite_sampler, in.uv.xy + uv_offset) * in.color;
     if (color.a < 0.001) {
-            discard;
+        discard;
     }
     return color;
     #else
-    var color = textureSample(sprite_texture, sprite_sampler, in.uv.xy, in.tile_id) * in.color;
+    let color = textureSample(sprite_texture, sprite_sampler, in.uv.xy, in.tile_id) * in.color;
     if (color.a < 0.001) {
-            discard;
+        discard;
     }
     return color;
     #endif

--- a/src/render/shaders/tilemap_vertex.wgsl
+++ b/src/render/shaders/tilemap_vertex.wgsl
@@ -45,34 +45,34 @@ struct VertexOutput {
 @vertex
 fn vertex(vertex_input: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    var animation_speed = vertex_input.position.z;
+    let animation_speed = vertex_input.position.z;
 
-    var mesh_data: MeshOutput = get_mesh(vertex_input.v_index, vec3(vertex_input.position.xy, 0.0));
+    let mesh_data: MeshOutput = get_mesh(vertex_input.v_index, vec3(vertex_input.position.xy, 0.0));
 
-    var frames: f32 = f32(vertex_input.uv.w - vertex_input.uv.z);
+    let frames: f32 = f32(vertex_input.uv.w - vertex_input.uv.z);
 
     var current_animation_frame = fract(tilemap_data.time * animation_speed) * frames;
 
     current_animation_frame = clamp(f32(vertex_input.uv.z) + current_animation_frame, f32(vertex_input.uv.z), f32(vertex_input.uv.w));
 
-    var texture_index: u32 = u32(current_animation_frame);
+    let texture_index: u32 = u32(current_animation_frame);
 
     #ifdef ATLAS
     // Get the top-left corner of the current frame in the texture, accounting for padding around the whole texture
     // as well as spacing between the tiles.
-    var columns: u32 = u32(round((tilemap_data.texture_size.x - tilemap_data.spacing.x) / (tilemap_data.tile_size.x + tilemap_data.spacing.x)));
-    var sprite_sheet_x: f32 = tilemap_data.spacing.x + floor(f32(texture_index % columns)) * (tilemap_data.tile_size.x + tilemap_data.spacing.x);
-    var sprite_sheet_y: f32 = tilemap_data.spacing.y + floor(f32(texture_index / columns)) * (tilemap_data.tile_size.y + tilemap_data.spacing.y);
+    let columns: u32 = u32(round((tilemap_data.texture_size.x - tilemap_data.spacing.x) / (tilemap_data.tile_size.x + tilemap_data.spacing.x)));
+    let sprite_sheet_x: f32 = tilemap_data.spacing.x + floor(f32(texture_index % columns)) * (tilemap_data.tile_size.x + tilemap_data.spacing.x);
+    let sprite_sheet_y: f32 = tilemap_data.spacing.y + floor(f32(texture_index / columns)) * (tilemap_data.tile_size.y + tilemap_data.spacing.y);
 
-    var start_u: f32 = sprite_sheet_x / tilemap_data.texture_size.x;
-    var end_u: f32 = (sprite_sheet_x + tilemap_data.tile_size.x) / tilemap_data.texture_size.x;
-    var start_v: f32 = sprite_sheet_y / tilemap_data.texture_size.y;
-    var end_v: f32 = (sprite_sheet_y + tilemap_data.tile_size.y) / tilemap_data.texture_size.y;
+    let start_u: f32 = sprite_sheet_x / tilemap_data.texture_size.x;
+    let end_u: f32 = (sprite_sheet_x + tilemap_data.tile_size.x) / tilemap_data.texture_size.x;
+    let start_v: f32 = sprite_sheet_y / tilemap_data.texture_size.y;
+    let end_v: f32 = (sprite_sheet_y + tilemap_data.tile_size.y) / tilemap_data.texture_size.y;
     #else
-    var start_u: f32 = 0.0;
-    var end_u: f32 = 1.0;
-    var start_v: f32 = 0.0;
-    var end_v: f32 = 1.0;
+    let start_u: f32 = 0.0;
+    let end_u: f32 = 1.0;
+    let start_v: f32 = 0.0;
+    let end_v: f32 = 1.0;
     #endif
 
     var atlas_uvs: array<vec4<f32>, 4>;


### PR DESCRIPTION
## Objective

There's a bunch of immutable data in our shaders that is declared with `var` rather than `let`. Let's fix that.

## Notes

Some of this should be `const` instead, according to the wgsl spec. But it seems like `const` has been in and out of the spec in the past and is not currently implemented in naga. See https://github.com/gfx-rs/naga/issues/1829

Tested all examples for functionality with/without the `atlas` feature.