### PR TITLE
Add missing example entries to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,22 @@ fn update_damage(
  - [`bench`](examples/bench.rs) - A stress test of the map rendering system. Takes a while to load.
  - [`chunking`](examples/chunking.rs) - A simple example showing how to implement an infinite tilemap by spawning multiple chunks.
  - [`colors`](examples/colors.rs) - Showcases how each tile can have an individual color.
+ - [`frustum_cull_test`](examples/frustum_cull_test.rs) - An environment for testing frustum culling.
  - [`game_of_life`](examples/game_of_life.rs) - A game of life simulator.
- - [`hex_column`](examples/hexagon_column.rs) - A map that is meshed using “pointy” hexagons.
- - [`hex_row`](examples/hexagon_row.rs) - A map that is meshed using flat hexagons.
+ - [`hexagon_column`](examples/hexagon_column.rs) - A map that is meshed using “pointy” hexagons.
+ - [`hexagon_generation`](examples/hexagon_generation.rs) - Shows how to generate hexagonal maps.
+ - [`hexagon_row`](examples/hexagon_row.rs) - A map that is meshed using flat hexagons.
  - [`iso_diamond`](examples/iso_diamond.rs) - An isometric meshed map using diamond ordering.
  - [`iso_staggered`](examples/iso_staggered.rs) - An isometric meshed map using staggered ordering.
  - [`layers`](examples/layers.rs) - An example of how you can use multiple map entities/components for “layers”.
- - [`ldtk`](examples/ldtk.rs) - An example of loading and rendering of a LDTK map. Use: `cargo run --example ldtk`. We recommend checking out: [`bevy_ecs_ldtk`](https://crates.io/crates/bevy_ecs_ldtk).
+ - [`ldtk`](examples/ldtk.rs) - An example of loading and rendering of a LDTK map. Use: `cargo run --example ldtk`. We recommend checking out: [`bevy_ecs_ldtk`] (https://crates.io/crates/bevy_ecs_ldtk).
+ - [`mouse_to_tile`](examples/mouse_to_tile.rs) - Shows how to convert a mouse cursor position into a tile position.
+ - [`move_tile`](examples/move_tile.rs) - Shows how to move a tile without despawning and respawning it.
  - [`random_map`](examples/random_map.rs) - A bench of editing all of the tiles every 100 ms.
  - [`remove_tiles`](examples/remove_tiles.rs) - An example showing how you can remove tiles by using map_query
- - [`tiled_rotated`](examples/tiled_rotated.rs) - An example of loading and rendering of a tiled map editor map with flipping and rotation. Use: `cargo run --example tiled_rotated`
+ - [`spacing`](examples/spacing.rs) - Shows how to load tilemap textures that contain spacing between the tiles.
  - [`tiled`](examples/tiled.rs) - An example of loading and rendering of a tiled map editor map. Use: `cargo run --example tiled`
+ - [`tiled_rotated`](examples/tiled_rotated.rs) - An example of loading and rendering of a tiled map editor map with flipping and rotation. Use: `cargo run  --example tiled_rotated`
  - [`visibility`](examples/visibility.rs) - An example showcasing visibility of tiles and chunks.
 
 ### Running Examples


### PR DESCRIPTION
`frustum_cull_test`, `hexagon_generation`, `mouse_to_tile`, `move_tile` and `spacing` were missing.

`hexagon_column` and `hexagon_row` had incorrect names.

`tiled_rotated` was not in the correct spot alphabetically.