### PR TITLE
Add missing #[reflect(Component)] annotations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 
 use bevy::prelude::{
     Bundle, Changed, Component, ComputedVisibility, CoreStage, Deref, GlobalTransform, Plugin,
-    Query, Reflect, Transform, Visibility,
+    Query, Reflect, ReflectComponent, Transform, Visibility,
 };
 use map::{
     TilemapGridSize, TilemapSize, TilemapSpacing, TilemapTexture, TilemapTextureSize,
@@ -82,6 +82,7 @@ impl Plugin for TilemapPlugin {
 }
 
 #[derive(Component, Reflect, Debug, Clone, Copy, Deref)]
+#[reflect(Component)]
 pub struct FrustumCulling(pub bool);
 
 impl Default for FrustumCulling {

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -1,5 +1,5 @@
 use bevy::asset::Assets;
-use bevy::prelude::{Res, ResMut, Resource};
+use bevy::prelude::{ReflectComponent, Res, ResMut, Resource};
 use bevy::render::render_resource::TextureUsages;
 use bevy::{
     math::{UVec2, Vec2},
@@ -34,6 +34,7 @@ pub struct TilemapRenderSettings {
 
 /// A component which stores a reference to the tilemap entity.
 #[derive(Component, Reflect, Clone, Copy, Debug, Hash)]
+#[reflect(Component)]
 pub struct TilemapId(pub Entity);
 
 impl Default for TilemapId {
@@ -44,6 +45,7 @@ impl Default for TilemapId {
 
 /// Size of the tilemap in tiles.
 #[derive(Component, Reflect, Default, Clone, Copy, Debug, Hash)]
+#[reflect(Component)]
 pub struct TilemapSize {
     pub x: u32,
     pub y: u32,
@@ -74,6 +76,7 @@ impl From<UVec2> for TilemapSize {
 }
 
 #[derive(Component, Reflect, Clone, Debug, Hash, PartialEq, Eq)]
+#[reflect(Component)]
 pub enum TilemapTexture {
     /// All textures for tiles are inside a single image asset.
     Single(Handle<Image>),
@@ -175,6 +178,7 @@ impl TilemapTexture {
 
 /// Size of the tiles in pixels
 #[derive(Component, Reflect, Default, Clone, Copy, Debug, PartialOrd, PartialEq)]
+#[reflect(Component)]
 pub struct TilemapTileSize {
     pub x: f32,
     pub y: f32,
@@ -213,6 +217,7 @@ impl From<Vec2> for TilemapTileSize {
 /// Ex. A 16x16 pixel tile can be overlapped by 8 pixels by using
 /// a grid size of 16x8.
 #[derive(Component, Reflect, Default, Clone, Copy, Debug, PartialOrd, PartialEq)]
+#[reflect(Component)]
 pub struct TilemapGridSize {
     pub x: f32,
     pub y: f32,
@@ -245,6 +250,7 @@ impl From<&Vec2> for TilemapGridSize {
 /// Spacing between tiles in pixels inside of the texture atlas.
 /// Defaults to 0.0
 #[derive(Component, Reflect, Default, Clone, Copy, Debug)]
+#[reflect(Component)]
 pub struct TilemapSpacing {
     pub x: f32,
     pub y: f32,
@@ -264,6 +270,7 @@ impl TilemapSpacing {
 
 /// Size of the atlas texture in pixels.
 #[derive(Component, Reflect, Default, Clone, Copy, Debug)]
+#[reflect(Component)]
 pub struct TilemapTextureSize {
     pub x: f32,
     pub y: f32,
@@ -311,6 +318,7 @@ pub enum IsoCoordSystem {
 
 /// The type of tile to be rendered, currently we support: Square, Hex, and Isometric.
 #[derive(Component, Reflect, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[reflect(Component)]
 pub enum TilemapType {
     /// A tilemap with rectangular tiles.
     Square,

--- a/src/tiles/mod.rs
+++ b/src/tiles/mod.rs
@@ -2,7 +2,7 @@ mod storage;
 
 use bevy::{
     math::{UVec2, Vec2},
-    prelude::{Bundle, Color, Component, Reflect},
+    prelude::{Bundle, Color, Component, Reflect, ReflectComponent},
 };
 pub use storage::*;
 
@@ -11,6 +11,7 @@ use crate::TilemapSize;
 
 /// A tile position in the tilemap grid.
 #[derive(Component, Reflect, Default, Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd)]
+#[reflect(Component)]
 pub struct TilePos {
     pub x: u32,
     pub y: u32,
@@ -65,10 +66,12 @@ impl From<&TilePos> for Vec2 {
 
 /// A texture index into the atlas or texture array for a single tile. Indices in an atlas are horizontal based.
 #[derive(Component, Reflect, Default, Clone, Copy, Debug, Hash)]
+#[reflect(Component)]
 pub struct TileTextureIndex(pub u32);
 
 /// A custom color for the tile.
 #[derive(Component, Reflect, Default, Clone, Copy, Debug)]
+#[reflect(Component)]
 pub struct TileColor(pub Color);
 
 impl From<Color> for TileColor {
@@ -79,6 +82,7 @@ impl From<Color> for TileColor {
 
 /// Hides or shows a tile based on the boolean. Default: True
 #[derive(Component, Reflect, Clone, Copy, Debug, Hash)]
+#[reflect(Component)]
 pub struct TileVisible(pub bool);
 
 impl Default for TileVisible {
@@ -89,6 +93,7 @@ impl Default for TileVisible {
 
 /// Flips the tiles texture along the X, Y or diagonal axes
 #[derive(Component, Reflect, Default, Clone, Copy, Debug, Hash)]
+#[reflect(Component)]
 pub struct TileFlip {
     /// Flip tile along the x axis.
     pub x: bool,
@@ -110,6 +115,7 @@ pub struct TileBundle {
 }
 
 #[derive(Component, Reflect, Default, Clone, Copy, Debug)]
+#[reflect(Component)]
 pub struct TilePosOld(pub TilePos);
 
 /// A component that is attached to a Tile entity that

--- a/src/tiles/storage.rs
+++ b/src/tiles/storage.rs
@@ -7,6 +7,7 @@ use super::TilePos;
 /// Used to store tile entities for fast look up.
 /// Tile entities are stored in a grid. The grid is always filled with None.
 #[derive(Component, Reflect, Default, Debug, Clone)]
+#[reflect(Component)]
 pub struct TileStorage {
     tiles: Vec<Option<Entity>>,
     pub size: TilemapSize,


### PR DESCRIPTION
Adds #[reflect(Component)] for all components except AnimatedTile, which doesn't implement Default.