### PR TITLE
Fix tiles sometimes not displaying after tiles are removed and added

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -233,7 +233,10 @@ impl Plugin for TilemapRenderingPlugin {
             .add_system_to_stage(RenderStage::Extract, extract::extract_removal);
         render_app
             .add_system_to_stage(RenderStage::Prepare, prepare::prepare)
-            .add_system_to_stage(RenderStage::Prepare, prepare::prepare_removal)
+            .add_system_to_stage(
+                RenderStage::Prepare,
+                prepare::prepare_removal.before(prepare::prepare),
+            )
             .add_system_to_stage(RenderStage::Queue, queue::queue_meshes)
             .add_system_to_stage(RenderStage::Queue, queue::queue_transform_bind_group)
             .add_system_to_stage(RenderStage::Queue, queue::queue_tilemap_bind_group)


### PR DESCRIPTION
Fixes #362

It should be easy to reproduce the bug and demonstrate that this fixes it by changing the `before` to `after`.