### PR TITLE
Fix panic when despawning tiles that have changed

### DIFF
--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -281,7 +281,10 @@ pub fn extract(
             color: color.0.into(),
         };
 
-        let data = tilemap_query.get(tilemap_id.0).unwrap();
+        let data = match tilemap_query.get(tilemap_id.0) {
+            Ok(data) => data,
+            Err(_) => continue,
+        };
 
         extracted_tilemaps.insert(
             data.0,


### PR DESCRIPTION
Right now, when you despawn a tile that has had one of its `bevy_ecs_tilemap` specific components changed in the same frame, your game will panic. 

I tracked the behaviour down to the logic extracting tile info for rendering, where a `get` on a `Query` is unwrapped. The fix, instead, just skips extracting the tile in question if the entity for it has been despawned - it occurs before any of the mutations, so there shouldn't be any dangling data left over by `continue`ing. I haven't added a log for the `Err`, since it seems like the only time this unwrap fails is when the entity can't be found in the query, which should be unexceptional.

<details><summary>Changing levels with the patched version - water tiles are animated by changing the `TileTextureIndex`, which causes the panic when the `TileStorage` for the animated layer is despawned</summary>


https://user-images.githubusercontent.com/2522620/212593486-b91e4c23-05b9-43ef-8061-bff19f991bb2.mp4


</details>