### PR TITLE
Treat TilePos as a value type in APIs

### DIFF
--- a/examples/accessing_tiles.rs
+++ b/examples/accessing_tiles.rs
@@ -45,17 +45,17 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 })
                 .id();
             // Here we let the tile storage component know what tiles we have.
-            tile_storage.set(&tile_pos, tile_entity);
+            tile_storage.set(tile_pos, tile_entity);
         }
     }
 
     // We can grab a list of neighbors.
     let neighbor_positions =
-        Neighbors::get_square_neighboring_positions(&TilePos { x: 0, y: 0 }, &map_size, true);
+        Neighbors::get_square_neighboring_positions(TilePos { x: 0, y: 0 }, &map_size, true);
     let neighbor_entities = neighbor_positions.entities(&tile_storage);
 
     // We can access tiles using:
-    assert!(tile_storage.get(&TilePos { x: 0, y: 0 }).is_some());
+    assert!(tile_storage.get(TilePos { x: 0, y: 0 }).is_some());
     assert_eq!(neighbor_entities.iter().count(), 3); // Only 3 neighbors since negative is outside of map.
 
     // This changes some of our tiles by looking at neighbors.
@@ -66,11 +66,11 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
             // Grabbing neighbors is easy.
 
             let neighbors =
-                Neighbors::get_square_neighboring_positions(&TilePos { x, y }, &map_size, true);
+                Neighbors::get_square_neighboring_positions(TilePos { x, y }, &map_size, true);
             for pos in neighbors.iter() {
                 // We can replace the tile texture component like so:
                 commands
-                    .entity(tile_storage.get(pos).unwrap())
+                    .entity(tile_storage.get(*pos).unwrap())
                     .insert(TileTextureIndex(color));
             }
         }
@@ -123,7 +123,7 @@ fn update_map(
                 for y in (2..128).step_by(4) {
                     // Grab the neighboring tiles
                     let neighboring_entities = Neighbors::get_square_neighboring_positions(
-                        &TilePos { x, y },
+                        TilePos { x, y },
                         map_size,
                         true,
                     )

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -106,7 +106,7 @@ fn create_animated_flowers(mut commands: Commands, asset_server: Res<AssetServer
             ))
             .id();
 
-        tile_storage.set(&tile_pos, tile_entity);
+        tile_storage.set(tile_pos, tile_entity);
     }
     let map_type = TilemapType::Square;
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -41,7 +41,7 @@ fn startup(
                     ..Default::default()
                 })
                 .id();
-            tile_storage.set(&tile_pos, tile_entity);
+            tile_storage.set(tile_pos, tile_entity);
         }
     }
 

--- a/examples/chunking.rs
+++ b/examples/chunking.rs
@@ -28,7 +28,7 @@ fn spawn_chunk(commands: &mut Commands, asset_server: &AssetServer, chunk_pos: I
                 })
                 .id();
             commands.entity(tilemap_entity).add_child(tile_entity);
-            tile_storage.set(&tile_pos, tile_entity);
+            tile_storage.set(tile_pos, tile_entity);
         }
     }
 

--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -25,7 +25,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..Default::default()
                 })
                 .id();
-            tile_storage.set(&tile_pos, tile_entity);
+            tile_storage.set(tile_pos, tile_entity);
             i += 1;
         }
     }
@@ -63,7 +63,7 @@ fn update(
     if current_time - last_update.0 > 0.1 {
         for (entity, position, visibility) in tile_query.iter() {
             let neighbor_count =
-                Neighbors::get_square_neighboring_positions(position, map_size, true)
+                Neighbors::get_square_neighboring_positions(*position, map_size, true)
                     .entities(tile_storage)
                     .iter()
                     .filter(|neighbor| {

--- a/examples/helpers/ldtk.rs
+++ b/examples/helpers/ldtk.rs
@@ -197,7 +197,7 @@ pub fn process_loaded_tile_maps(
                                 })
                                 .id();
 
-                            storage.set(&position, tile_entity);
+                            storage.set(position, tile_entity);
                         }
 
                         let grid_size = tile_size.into();

--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -326,7 +326,7 @@ pub fn process_loaded_maps(
                                         ..Default::default()
                                     })
                                     .id();
-                                tile_storage.set(&tile_pos, tile_entity);
+                                tile_storage.set(tile_pos, tile_entity);
                             }
                         }
 

--- a/examples/hex_neighbors.rs
+++ b/examples/hex_neighbors.rs
@@ -334,7 +334,7 @@ fn hover_highlight_tile_label(
             TilePos::from_world_pos(&cursor_in_map_pos, map_size, grid_size, map_type)
         {
             // Highlight the relevant tile's label
-            if let Some(tile_entity) = tile_storage.get(&tile_pos) {
+            if let Some(tile_entity) = tile_storage.get(tile_pos) {
                 if let Ok(label) = tile_label_q.get(tile_entity) {
                     if let Ok(mut tile_text) = text_q.get_mut(label.0) {
                         for mut section in tile_text.sections.iter_mut() {
@@ -385,12 +385,12 @@ fn highlight_neighbor_label(
 
         for hovered_tile_pos in hovered_tiles_q.iter() {
             let neighboring_positions =
-                HexNeighbors::get_neighboring_positions(hovered_tile_pos, map_size, hex_coord_sys);
+                HexNeighbors::get_neighboring_positions(*hovered_tile_pos, map_size, hex_coord_sys);
 
             for neighbor_pos in neighboring_positions.iter() {
                 // We want to ensure that the tile position lies within the tile map, so we do a
                 // `checked_get`.
-                if let Some(tile_entity) = tile_storage.checked_get(neighbor_pos) {
+                if let Some(tile_entity) = tile_storage.checked_get(*neighbor_pos) {
                     if let Ok(label) = tile_label_q.get(tile_entity) {
                         if let Ok(mut tile_text) = text_q.get_mut(label.0) {
                             for mut section in tile_text.sections.iter_mut() {
@@ -424,14 +424,14 @@ fn highlight_neighbor_label(
                         // Get the neighbor in a particular direction.
                         // This function does not check to see if the calculated neighbor lies
                         // within the tile map.
-                        hex_direction.offset(hovered_tile_pos, *hex_coord_sys)
+                        hex_direction.offset(*hovered_tile_pos, *hex_coord_sys)
                     }
                     _ => unreachable!(),
                 };
 
                 // We want to ensure that the tile position lies within the tile map, so we do a
                 // `checked_get`.
-                if let Some(tile_entity) = tile_storage.checked_get(&tile_pos) {
+                if let Some(tile_entity) = tile_storage.checked_get(tile_pos) {
                     if let Ok(label) = tile_label_q.get(tile_entity) {
                         if let Ok(mut tile_text) = text_q.get_mut(label.0) {
                             for mut section in tile_text.sections.iter_mut() {

--- a/examples/mouse_to_tile.rs
+++ b/examples/mouse_to_tile.rs
@@ -379,7 +379,7 @@ fn highlight_tile_labels(
             TilePos::from_world_pos(&cursor_in_map_pos, map_size, grid_size, map_type)
         {
             // Highlight the relevant tile's label
-            if let Some(tile_entity) = tile_storage.get(&tile_pos) {
+            if let Some(tile_entity) = tile_storage.get(tile_pos) {
                 if let Ok(label) = tile_label_q.get(tile_entity) {
                     if let Ok(mut tile_text) = text_q.get_mut(label.0) {
                         for mut section in tile_text.sections.iter_mut() {

--- a/examples/move_tile.rs
+++ b/examples/move_tile.rs
@@ -24,7 +24,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ..Default::default()
         })
         .id();
-    tile_storage.set(&tile_pos, tile_entity);
+    tile_storage.set(tile_pos, tile_entity);
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
     let grid_size = tile_size.into();

--- a/examples/random_map.rs
+++ b/examples/random_map.rs
@@ -29,7 +29,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     LastUpdate::default(),
                 ))
                 .id();
-            tile_storage.set(&tile_pos, tile_entity);
+            tile_storage.set(tile_pos, tile_entity);
         }
     }
 

--- a/examples/remove_tiles.rs
+++ b/examples/remove_tiles.rs
@@ -23,7 +23,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..Default::default()
                 })
                 .id();
-            tile_storage.set(&tile_pos, tile_entity);
+            tile_storage.set(tile_pos, tile_entity);
         }
     }
 
@@ -66,10 +66,10 @@ fn remove_tiles(
                 y: random.gen_range(0..32),
             };
 
-            if let Some(tile_entity) = tile_storage.get(&position) {
+            if let Some(tile_entity) = tile_storage.get(position) {
                 commands.entity(tile_entity).despawn_recursive();
                 // Don't forget to remove tiles from the tile storage!
-                tile_storage.remove(&position);
+                tile_storage.remove(position);
             }
 
             last_update.value = current_time;

--- a/examples/texture_container.rs
+++ b/examples/texture_container.rs
@@ -44,7 +44,7 @@ mod no_atlas {
         let tilemap_id = TilemapId(tilemap_entity);
 
         let tile_positions = generate_hexagon(
-            AxialPos::from_tile_pos_given_coord_system(&MAP_CENTER, COORD_SYS),
+            AxialPos::from_tile_pos_given_coord_system(MAP_CENTER, COORD_SYS),
             MAP_RADIUS,
         )
         .into_iter()
@@ -69,7 +69,7 @@ mod no_atlas {
                     ..Default::default()
                 })
                 .id();
-            tile_storage.set(&position, tile_entity);
+            tile_storage.set(position, tile_entity);
         }
 
         let tile_size = TILE_SIZE;

--- a/examples/texture_vec.rs
+++ b/examples/texture_vec.rs
@@ -38,7 +38,7 @@ mod no_atlas {
         let tilemap_id = TilemapId(tilemap_entity);
 
         let tile_positions = generate_hexagon(
-            AxialPos::from_tile_pos_given_coord_system(&MAP_CENTER, COORD_SYS),
+            AxialPos::from_tile_pos_given_coord_system(MAP_CENTER, COORD_SYS),
             MAP_RADIUS,
         )
         .into_iter()
@@ -63,7 +63,7 @@ mod no_atlas {
                     ..Default::default()
                 })
                 .id();
-            tile_storage.set(&position, tile_entity);
+            tile_storage.set(position, tile_entity);
         }
 
         let tile_size = TILE_SIZE;

--- a/examples/visibility.rs
+++ b/examples/visibility.rs
@@ -23,7 +23,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..Default::default()
                 })
                 .id();
-            tile_storage.set(&tile_pos, tile_entity);
+            tile_storage.set(tile_pos, tile_entity);
         }
     }
 
@@ -67,7 +67,7 @@ fn remove_tiles(
             };
 
             // Instead of removing the tile entity we want to hide the tile by removing the Visible component.
-            if let Some(tile_entity) = tile_storage.get(&position) {
+            if let Some(tile_entity) = tile_storage.get(position) {
                 let mut visibility = tile_query.get_mut(tile_entity).unwrap();
                 visibility.0 = !visibility.0;
             }

--- a/src/helpers/filling.rs
+++ b/src/helpers/filling.rs
@@ -27,7 +27,7 @@ pub fn fill_tilemap(
                 })
                 .id();
             commands.entity(tilemap_id.0).add_child(tile_entity);
-            tile_storage.set(&tile_pos, tile_entity);
+            tile_storage.set(tile_pos, tile_entity);
         }
     }
 }
@@ -59,7 +59,7 @@ pub fn fill_tilemap_rect(
                     ..Default::default()
                 })
                 .id();
-            tile_storage.set(&tile_pos, tile_entity);
+            tile_storage.set(tile_pos, tile_entity);
         }
     }
 }
@@ -93,7 +93,7 @@ pub fn fill_tilemap_rect_color(
                     ..Default::default()
                 })
                 .id();
-            tile_storage.set(&tile_pos, tile_entity);
+            tile_storage.set(tile_pos, tile_entity);
         }
     }
 }
@@ -152,7 +152,7 @@ pub fn fill_tilemap_hexagon(
     tile_storage: &mut TileStorage,
 ) {
     let tile_positions = generate_hexagon(
-        AxialPos::from_tile_pos_given_coord_system(&origin, hex_coord_system),
+        AxialPos::from_tile_pos_given_coord_system(origin, hex_coord_system),
         radius,
     )
     .into_iter()
@@ -168,6 +168,6 @@ pub fn fill_tilemap_hexagon(
                 ..Default::default()
             })
             .id();
-        tile_storage.checked_set(&tile_pos, tile_entity)
+        tile_storage.checked_set(tile_pos, tile_entity)
     }
 }

--- a/src/helpers/hex_grid/axial.rs
+++ b/src/helpers/hex_grid/axial.rs
@@ -35,8 +35,8 @@ pub struct AxialPos {
     pub r: i32,
 }
 
-impl From<&TilePos> for AxialPos {
-    fn from(tile_pos: &TilePos) -> Self {
+impl From<TilePos> for AxialPos {
+    fn from(tile_pos: TilePos) -> Self {
         AxialPos {
             q: tile_pos.x as i32,
             r: tile_pos.y as i32,
@@ -430,7 +430,7 @@ impl AxialPos {
     /// coordinate system before being returned as a `TilePos`.
     #[inline]
     pub fn from_tile_pos_given_coord_system(
-        tile_pos: &TilePos,
+        tile_pos: TilePos,
         hex_coord_sys: HexCoordSystem,
     ) -> AxialPos {
         match hex_coord_sys {

--- a/src/helpers/hex_grid/neighbors.rs
+++ b/src/helpers/hex_grid/neighbors.rs
@@ -151,7 +151,7 @@ impl Sub<i32> for HexDirection {
 }
 
 impl HexDirection {
-    pub fn offset(&self, tile_pos: &TilePos, coord_sys: HexCoordSystem) -> TilePos {
+    pub fn offset(&self, tile_pos: TilePos, coord_sys: HexCoordSystem) -> TilePos {
         AxialPos::from_tile_pos_given_coord_system(tile_pos, coord_sys)
             .offset(*self)
             .as_tile_pos_given_coord_system(coord_sys)
@@ -233,7 +233,7 @@ impl From<HexColDirection> for HexDirection {
 
 impl HexRowDirection {
     #[inline]
-    pub fn offset(&self, tile_pos: &TilePos, coord_sys: HexCoordSystem) -> TilePos {
+    pub fn offset(&self, tile_pos: TilePos, coord_sys: HexCoordSystem) -> TilePos {
         AxialPos::from_tile_pos_given_coord_system(tile_pos, coord_sys)
             .offset_compass_row(*self)
             .as_tile_pos_given_coord_system(coord_sys)
@@ -242,7 +242,7 @@ impl HexRowDirection {
 
 impl HexColDirection {
     #[inline]
-    pub fn offset(&self, tile_pos: &TilePos, coord_sys: HexCoordSystem) -> TilePos {
+    pub fn offset(&self, tile_pos: TilePos, coord_sys: HexCoordSystem) -> TilePos {
         AxialPos::from_tile_pos_given_coord_system(tile_pos, coord_sys)
             .offset_compass_col(*self)
             .as_tile_pos_given_coord_system(coord_sys)
@@ -412,7 +412,7 @@ impl HexNeighbors<TilePos> {
     /// on the map.
     #[inline]
     pub fn get_neighboring_positions(
-        tile_pos: &TilePos,
+        tile_pos: TilePos,
         map_size: &TilemapSize,
         hex_coord_sys: &HexCoordSystem,
     ) -> HexNeighbors<TilePos> {
@@ -451,7 +451,7 @@ impl HexNeighbors<TilePos> {
     /// on the map.
     #[inline]
     pub fn get_neighboring_positions_standard(
-        tile_pos: &TilePos,
+        tile_pos: TilePos,
         map_size: &TilemapSize,
     ) -> HexNeighbors<TilePos> {
         let axial_pos = AxialPos::from(tile_pos);
@@ -469,7 +469,7 @@ impl HexNeighbors<TilePos> {
     /// on the map.
     #[inline]
     pub fn get_neighboring_positions_row_even(
-        tile_pos: &TilePos,
+        tile_pos: TilePos,
         map_size: &TilemapSize,
     ) -> HexNeighbors<TilePos> {
         let axial_pos = AxialPos::from(RowEvenPos::from(tile_pos));
@@ -485,7 +485,7 @@ impl HexNeighbors<TilePos> {
     /// on the map.
     #[inline]
     pub fn get_neighboring_positions_row_odd(
-        tile_pos: &TilePos,
+        tile_pos: TilePos,
         map_size: &TilemapSize,
     ) -> HexNeighbors<TilePos> {
         let axial_pos = AxialPos::from(RowOddPos::from(tile_pos));
@@ -501,7 +501,7 @@ impl HexNeighbors<TilePos> {
     /// on the map.
     #[inline]
     pub fn get_neighboring_positions_col_even(
-        tile_pos: &TilePos,
+        tile_pos: TilePos,
         map_size: &TilemapSize,
     ) -> HexNeighbors<TilePos> {
         let axial_pos = AxialPos::from(ColEvenPos::from(tile_pos));
@@ -517,7 +517,7 @@ impl HexNeighbors<TilePos> {
     /// on the map.
     #[inline]
     pub fn get_neighboring_positions_col_odd(
-        tile_pos: &TilePos,
+        tile_pos: TilePos,
         map_size: &TilemapSize,
     ) -> HexNeighbors<TilePos> {
         let axial_pos = AxialPos::from(ColOddPos::from(tile_pos));
@@ -530,7 +530,7 @@ impl HexNeighbors<TilePos> {
     /// Returns the entities associated with each tile position.
     #[inline]
     pub fn entities(&self, tile_storage: &TileStorage) -> HexNeighbors<Entity> {
-        let f = |tile_pos| tile_storage.get(tile_pos);
+        let f = |tile_pos: &TilePos| tile_storage.get(*tile_pos);
         self.and_then_ref(f)
     }
 }

--- a/src/helpers/hex_grid/offset.rs
+++ b/src/helpers/hex_grid/offset.rs
@@ -82,9 +82,9 @@ impl RowOddPos {
     }
 }
 
-impl From<&TilePos> for RowOddPos {
+impl From<TilePos> for RowOddPos {
     #[inline]
-    fn from(tile_pos: &TilePos) -> Self {
+    fn from(tile_pos: TilePos) -> Self {
         RowOddPos {
             q: tile_pos.x as i32,
             r: tile_pos.y as i32,
@@ -168,9 +168,9 @@ impl RowEvenPos {
     }
 }
 
-impl From<&TilePos> for RowEvenPos {
+impl From<TilePos> for RowEvenPos {
     #[inline]
-    fn from(tile_pos: &TilePos) -> Self {
+    fn from(tile_pos: TilePos) -> Self {
         RowEvenPos {
             q: tile_pos.x as i32,
             r: tile_pos.y as i32,
@@ -254,9 +254,9 @@ impl ColOddPos {
     }
 }
 
-impl From<&TilePos> for ColOddPos {
+impl From<TilePos> for ColOddPos {
     #[inline]
-    fn from(tile_pos: &TilePos) -> Self {
+    fn from(tile_pos: TilePos) -> Self {
         ColOddPos {
             q: tile_pos.x as i32,
             r: tile_pos.y as i32,
@@ -340,9 +340,9 @@ impl ColEvenPos {
     }
 }
 
-impl From<&TilePos> for ColEvenPos {
+impl From<TilePos> for ColEvenPos {
     #[inline]
-    fn from(tile_pos: &TilePos) -> Self {
+    fn from(tile_pos: TilePos) -> Self {
         ColEvenPos {
             q: tile_pos.x as i32,
             r: tile_pos.y as i32,

--- a/src/helpers/projection.rs
+++ b/src/helpers/projection.rs
@@ -11,7 +11,7 @@ impl TilePos {
     /// Get the center of this tile in world space.
     ///
     /// The center is well defined for all [`TilemapType`](crate::map::TilemapType)s.
-    pub fn center_in_world(&self, grid_size: &TilemapGridSize, map_type: &TilemapType) -> Vec2 {
+    pub fn center_in_world(self, grid_size: &TilemapGridSize, map_type: &TilemapType) -> Vec2 {
         match map_type {
             TilemapType::Square { .. } => {
                 Vec2::new(grid_size.x * (self.x as f32), grid_size.y * (self.y as f32))

--- a/src/helpers/square_grid/mod.rs
+++ b/src/helpers/square_grid/mod.rs
@@ -57,9 +57,9 @@ impl Mul<SquarePos> for i32 {
     }
 }
 
-impl From<&TilePos> for SquarePos {
+impl From<TilePos> for SquarePos {
     #[inline]
-    fn from(tile_pos: &TilePos) -> Self {
+    fn from(tile_pos: TilePos) -> Self {
         Self {
             x: tile_pos.x as i32,
             y: tile_pos.y as i32,
@@ -176,7 +176,7 @@ impl TilePos {
     /// and assuming that this is a map using the standard (non-isometric) square coordinate system
     #[inline]
     pub fn square_offset(
-        &self,
+        self,
         direction: &SquareDirection,
         map_size: &TilemapSize,
     ) -> Option<TilePos> {

--- a/src/helpers/square_grid/neighbors.rs
+++ b/src/helpers/square_grid/neighbors.rs
@@ -331,7 +331,7 @@ impl Neighbors<TilePos> {
     /// A tile position will be `None` for a particular direction, if that neighbor would not lie
     /// on the map.
     pub fn get_square_neighboring_positions(
-        tile_pos: &TilePos,
+        tile_pos: TilePos,
         map_size: &TilemapSize,
         include_diagonals: bool,
     ) -> Neighbors<TilePos> {
@@ -360,7 +360,7 @@ impl Neighbors<TilePos> {
     /// A tile position will be `None` for a particular direction, if that neighbor would not lie
     /// on the map.
     pub fn get_staggered_neighboring_positions(
-        tile_pos: &TilePos,
+        tile_pos: TilePos,
         map_size: &TilemapSize,
         include_diagonals: bool,
     ) -> Neighbors<TilePos> {
@@ -385,7 +385,7 @@ impl Neighbors<TilePos> {
 
     /// Returns the entities associated with each tile position.
     pub fn entities(&self, tile_storage: &TileStorage) -> Neighbors<Entity> {
-        let f = |tile_pos| tile_storage.get(tile_pos);
+        let f = |tile_pos: &TilePos| tile_storage.get(*tile_pos);
         self.and_then_ref(f)
     }
 }

--- a/src/helpers/square_grid/staggered.rs
+++ b/src/helpers/square_grid/staggered.rs
@@ -20,8 +20,8 @@ pub struct StaggeredPos {
     pub y: i32,
 }
 
-impl From<&TilePos> for StaggeredPos {
-    fn from(tile_pos: &TilePos) -> Self {
+impl From<TilePos> for StaggeredPos {
+    fn from(tile_pos: TilePos) -> Self {
         Self {
             x: tile_pos.x as i32,
             y: tile_pos.y as i32,
@@ -150,7 +150,7 @@ impl TilePos {
     /// and assuming that this is a map that is using the isometric staggered coordinate system.
     #[inline]
     pub fn staggered_offset(
-        &self,
+        self,
         direction: &SquareDirection,
         map_size: &TilemapSize,
     ) -> Option<TilePos> {

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -115,9 +115,8 @@ impl ExtractedTilemapTexture {
                     let this_tile_size: TilemapTileSize = image.size().into();
                     if this_tile_size != tile_size {
                         panic!(
-                            "Expected all provided image assets to have size {:?}, \
-                                    but found image with size: {:?}",
-                            tile_size, this_tile_size
+                            "Expected all provided image assets to have size {tile_size:?}, \
+                                    but found image with size: {this_tile_size:?}"
                         );
                     }
                 }

--- a/src/render/texture_array_cache.rs
+++ b/src/render/texture_array_cache.rs
@@ -90,9 +90,8 @@ impl TextureArrayCache {
                     let this_tile_size: TilemapTileSize = image.size().try_into().unwrap();
                     if this_tile_size != tile_size {
                         panic!(
-                            "Expected all provided image assets to have size {:?}, \
-                                    but found image with size: {:?}",
-                            tile_size, this_tile_size
+                            "Expected all provided image assets to have size {tile_size:?}, \
+                                    but found image with size: {this_tile_size:?}"
                         );
                     }
                 }

--- a/src/tiles/storage.rs
+++ b/src/tiles/storage.rs
@@ -26,7 +26,8 @@ impl TileStorage {
     /// position.
     ///
     /// Panics if the given `tile_pos` doesn't lie within the extents of the underlying tile map.
-    pub fn get(&self, tile_pos: &TilePos) -> Option<Entity> {
+    pub fn get<T: Into<TilePos>>(&self, tile_pos: T) -> Option<Entity> {
+        let tile_pos = tile_pos.into();
         self.tiles[tile_pos.to_index(&self.size)]
     }
 
@@ -34,7 +35,8 @@ impl TileStorage {
     /// 1) the tile position lies within the underlying tile map's extents *and*
     /// 2) there is an entity associated with that tile position;
     /// otherwise it returns `None`.
-    pub fn checked_get(&self, tile_pos: &TilePos) -> Option<Entity> {
+    pub fn checked_get<T: Into<TilePos>>(&self, tile_pos: T) -> Option<Entity> {
+        let tile_pos = tile_pos.into();
         if tile_pos.within_map_bounds(&self.size) {
             self.tiles[tile_pos.to_index(&self.size)]
         } else {
@@ -47,7 +49,7 @@ impl TileStorage {
     /// If there is an entity already at that position, it will be replaced.
     ///
     /// Panics if the given `tile_pos` doesn't lie within the extents of the underlying tile map.
-    pub fn set(&mut self, tile_pos: &TilePos, tile_entity: Entity) {
+    pub fn set(&mut self, tile_pos: TilePos, tile_entity: Entity) {
         self.tiles[tile_pos.to_index(&self.size)].replace(tile_entity);
     }
 
@@ -55,7 +57,7 @@ impl TileStorage {
     /// underlying tile map's extents.
     ///
     /// If there is an entity already at that position, it will be replaced.
-    pub fn checked_set(&mut self, tile_pos: &TilePos, tile_entity: Entity) {
+    pub fn checked_set(&mut self, tile_pos: TilePos, tile_entity: Entity) {
         if tile_pos.within_map_bounds(&self.size) {
             self.tiles[tile_pos.to_index(&self.size)].replace(tile_entity);
         }
@@ -74,7 +76,7 @@ impl TileStorage {
     /// Remove entity at the given tile position, if there was one, leaving `None` in its place.
     ///
     /// Panics if the given `tile_pos` doesn't lie within the extents of the underlying tile map.
-    pub fn remove(&mut self, tile_pos: &TilePos) {
+    pub fn remove(&mut self, tile_pos: TilePos) {
         self.tiles[tile_pos.to_index(&self.size)].take();
     }
 
@@ -82,7 +84,7 @@ impl TileStorage {
     /// the extents of the underlying map.
     ///
     /// Otherwise, nothing is done.
-    pub fn checked_remove(&mut self, tile_pos: &TilePos) {
+    pub fn checked_remove(&mut self, tile_pos: TilePos) {
         if tile_pos.within_map_bounds(&self.size) {
             self.tiles[tile_pos.to_index(&self.size)].take();
         }


### PR DESCRIPTION
Passing `TilePos` by value often makes the API a lot simpler to use (considering `TilePos` already implements `Copy`.

This also makes  `TileStorage::get` et. all generic over `Into<TilePos>`, which means you can now do:

```rust
let tile = tile_storage.get(uvec!(12, 34));
```