### PR TITLE
Only call get_mut on Images that need their TextureDescriptors changed.

### DIFF
--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -153,15 +153,19 @@ impl TilemapTexture {
     /// Sets images with the `COPY_SRC` flag.
     pub fn set_images_to_copy_src(&self, images: &mut ResMut<Assets<Image>>) {
         for handle in self.image_handles() {
-            if let Some(mut image) = images.get_mut(handle) {
+            // NOTE: We retrieve it non-mutably first to avoid triggering an `AssetEvent::Modified`
+            // if we didn't actually need to modify it
+            if let Some(image) = images.get(handle) {
                 if !image
                     .texture_descriptor
                     .usage
                     .contains(TextureUsages::COPY_SRC)
                 {
-                    image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING
-                        | TextureUsages::COPY_SRC
-                        | TextureUsages::COPY_DST;
+                    if let Some(mut image) = images.get_mut(handle) {
+                        image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING
+                            | TextureUsages::COPY_SRC
+                            | TextureUsages::COPY_DST;
+                    };
                 }
             }
         }


### PR DESCRIPTION
Calling get_mut triggers an AssetEvent::Modified, and this function is called every frame, for every image that is a TileTexture. These events are used by Bevy internally to re-copy texture data to the GPU, so the effect of this was that every TileTexture would be uploaded to the GPU every frame, regardless of whether it changed.

Fixes #391.