### PR TITLE
Use clone_weak when cloning tile textures in extraction to avoid making unnecessary work for Bevy's unused asset check.

### DIFF
--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -294,7 +294,7 @@ pub fn extract(
                     spacing: *data.3,
                     grid_size: *data.4,
                     map_type: *data.5,
-                    texture: data.6.clone(),
+                    texture: data.6.clone_weak(),
                     map_size: *data.7,
                     visibility: data.8.clone(),
                     frustum_culling: *data.9,
@@ -329,7 +329,7 @@ pub fn extract(
                         spacing: *data.3,
                         grid_size: *data.4,
                         map_type: *data.5,
-                        texture: data.6.clone(),
+                        texture: data.6.clone_weak(),
                         map_size: *data.7,
                         visibility: data.8.clone(),
                         frustum_culling: *data.9,
@@ -350,7 +350,7 @@ pub fn extract(
                 ExtractedTilemapTextureBundle {
                     data: ExtractedTilemapTexture::new(
                         entity,
-                        texture.clone(),
+                        texture.clone_weak(),
                         *tile_size,
                         *tile_spacing,
                         default_image_settings.0.min_filter,


### PR DESCRIPTION
On my usage of this with a large number of tile textures, I noticed a pretty significant amount of time being spent in Bevy's unused asset check every frame (1-2ms) even though no assets were becoming unused. It checks this by processing all the handle reference count changes during the frame, which indicated to me it must be something using `clone` on Handles.

Moving the `extract` code to use weak Handles instead of strong ones (which seems safe to me, the Tilemap should be holding a strong Handle to the texture anyway) removed that function from my trace entirely, so it's a pretty nice performance boost for larger amounts of textures.