### PR TITLE
Prepare for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ecs_tilemap"
 description = "A tilemap rendering plugin for bevy which is more ECS friendly by having an entity per tile."
-version = "0.9.0"
+version = "0.10.0"
 authors = ["John Mitchell"]
 homepage = "https://github.com/StarArawn/bevy_ecs_tilemap"
 repository = "https://github.com/StarArawn/bevy_ecs_tilemap"

--- a/README.md
+++ b/README.md
@@ -13,13 +13,7 @@ A tilemap rendering plugin for [`bevy`](https://bevyengine.org/). It is more ECS
  - Layers and sparse tile maps.
  - GPU powered animations.
  - Isometric and Hexagonal tile maps.
- - Initial support for Tiled file exports.
-
-## Upcoming Features
- - [x] Support for isometric and hexagon rendering.
- - [x] Built in animation support  – see [`animation` example](examples/animation.rs).
- - [x] Texture array support.
-
+ - Examples for integration with [Tiled](https://www.mapeditor.org/) and [LDTK](https://ldtk.io/) editors.
 
 ## Screenshots
 ![iso](screenshots/iso.png)
@@ -87,13 +81,13 @@ cargo run --target wasm32-unknown-unknown --example animation --release --featur
 
 ## Known Issues
  - Tile flipping by x, y and d, should work for all maps, however "d" (anti diagonal) flipping is not implemented for non-square maps.
- - Besides the above no known issues.
 
 ## Bevy Compatibility
 
 |bevy|bevy_ecs_tilemap|
 |---|---|
 |`main`|`bevy-track`|
+|0.10|0.10|
 |0.9|0.9|
 |0.8|0.8|
 |0.8|0.7|


### PR DESCRIPTION
Closes #398 

This updates the readme and `cargo.toml` for the 0.10 release. No need to merge until release time.

Feel free to close if this isn't helpful with your release plans.