### PR TITLE
Build docs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
   check:
     name: Run cargo check
 
+    env:
+      RUSTDOCFLAGS: -D warnings
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -41,6 +43,12 @@ jobs:
         with:
           command: check
           args: --all-targets --no-default-features
+
+      - name: Run cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --all-features --no-deps
 
   #   test:
   #     name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,21 +2,21 @@
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 name: Continuous Integration
 
 jobs:
   check:
     name: Run cargo check
-        
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-        
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -29,7 +29,7 @@ jobs:
         with:
           command: check
           args: --all-targets
-      
+
       - name: Run cargo check feature atlas
         uses: actions-rs/cargo@v1
         with:
@@ -42,29 +42,29 @@ jobs:
           command: check
           args: --all-targets --no-default-features
 
-#   test:
-#     name: Tests
-#     strategy:
-#       # Tests are most likely to have OS-specific behavior
-#       matrix:
-#         os: [ubuntu-latest, windows-latest, macOS-latest]
-        
-#     runs-on: ${{ matrix.os }}
-#     steps:
-#       - name: Checkout sources
-#         uses: actions/checkout@v2
-        
-#       - name: Install stable toolchain
-#         uses: actions-rs/toolchain@v1
-#         with:
-#           profile: minimal
-#           toolchain: stable
-#           override: true
+  #   test:
+  #     name: Tests
+  #     strategy:
+  #       # Tests are most likely to have OS-specific behavior
+  #       matrix:
+  #         os: [ubuntu-latest, windows-latest, macOS-latest]
 
-#       - name: Run cargo test
-#         uses: actions-rs/cargo@v1
-#         with:
-#           command: test
+  #     runs-on: ${{ matrix.os }}
+  #     steps:
+  #       - name: Checkout sources
+  #         uses: actions/checkout@v2
+
+  #       - name: Install stable toolchain
+  #         uses: actions-rs/toolchain@v1
+  #         with:
+  #           profile: minimal
+  #           toolchain: stable
+  #           override: true
+
+  #       - name: Run cargo test
+  #         uses: actions-rs/cargo@v1
+  #         with:
+  #           command: test
 
   build_examples:
     name: Build examples

--- a/src/helpers/hex_grid/axial.rs
+++ b/src/helpers/hex_grid/axial.rs
@@ -16,7 +16,7 @@ use std::ops::{Add, Mul, Sub};
 /// [`HexCoordSystem::Column`]. It is composed of a pair of `i32` digits named `q` and `r`. When
 /// converting from a [`TilePos`], `TilePos.x` is mapped to `q`, while `TilePos.y` is mapped to `r`.
 ///
-/// It is vector-like. In others: two `AxialPos` can be added/subtracted, and it can be multiplied
+/// It is vector-like. In other words: two `AxialPos` can be added/subtracted, and it can be multiplied
 /// by an `i32` scalar.
 ///
 /// Since this position type covers both [`HexCoordSystem::Row`] and [`HexCoordSystem::Column`],
@@ -212,7 +212,7 @@ pub const UNIT_R: AxialPos = AxialPos { q: 0, r: -1 };
 pub const UNIT_S: AxialPos = AxialPos { q: 1, r: -1 };
 
 impl AxialPos {
-    /// The magnitude of a cube position is its distance away from the `(0, 0)` hex_grid.
+    /// The magnitude of an axial position is its distance away from `(0, 0)` in the hex grid.
     ///
     /// See the Red Blob Games article for a [helpful interactive diagram](https://www.redblobgames.com/grids/hexagons/#distances-cube).
     #[inline]
@@ -221,7 +221,7 @@ impl AxialPos {
         cube_pos.magnitude()
     }
 
-    /// Returns the hex_grid distance between `self` and `other`.
+    /// Returns the distance between `self` and `other` on the hex grid.
     #[inline]
     pub fn distance_from(&self, other: &AxialPos) -> i32 {
         (*self - *other).magnitude()
@@ -229,9 +229,6 @@ impl AxialPos {
 
     /// Project a vector representing a fractional axial position (i.e. the components can be `f32`)
     /// into world space.
-    ///
-    /// This is a helper function for [`center_in_world_row`], [`corner_offset_in_world_row`] and
-    /// [`corner_in_world_row`].
     #[inline]
     pub fn project_row(axial_pos: Vec2, grid_size: &TilemapGridSize) -> Vec2 {
         let unscaled_pos = ROW_BASIS * axial_pos;
@@ -242,8 +239,9 @@ impl AxialPos {
     }
 
     /// Returns the center of a hex tile world space, assuming that:
-    ///     1) tiles are row-oriented ("pointy top"),
-    ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
+    ///
+    /// * Tiles are row-oriented ("pointy top"),
+    /// * The center of the hex grid with index `(0, 0)` is located at `[0.0, 0.0]`.
     #[inline]
     pub fn center_in_world_row(&self, grid_size: &TilemapGridSize) -> Vec2 {
         Self::project_row(Vec2::new(self.q as f32, self.r as f32), grid_size)
@@ -263,8 +261,9 @@ impl AxialPos {
 
     /// Returns the coordinate of the corner of a hex tile in the specified `corner_direction`,
     /// in world space, assuming that:
-    ///     1) tiles are row-oriented ("pointy top"),
-    ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
+    ///
+    /// * Tiles are row-oriented ("pointy top"),
+    /// * The center of the hex grid with index `(0, 0)` is located at `[0.0, 0.0]`.
     #[inline]
     pub fn corner_in_world_row(
         &self,
@@ -282,8 +281,9 @@ impl AxialPos {
     /// Project a vector, representing a fractional axial position (i.e. the components can be `f32`)
     /// on a column-oriented grid ("flat top"), into world space.
     ///
-    /// This is a helper function for [`center_in_world_col`], [`corner_offset_in_world_col`] and
-    /// [`corner_in_world_col`].
+    /// This is a helper function for [`center_in_world_col`](`Self::center_in_world_col`),
+    /// [`corner_offset_in_world_col`](`Self::corner_offset_in_world_col`) and
+    /// [`corner_in_world_col`](`Self::corner_in_world_col`).
     #[inline]
     pub fn project_col(axial_pos: Vec2, grid_size: &TilemapGridSize) -> Vec2 {
         let unscaled_pos = COL_BASIS * axial_pos;
@@ -294,8 +294,9 @@ impl AxialPos {
     }
 
     /// Returns the center of a hex tile world space, assuming that:
-    ///     1) tiles are col-oriented ("flat top"),
-    ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
+    ///
+    /// * Tiles are column-oriented ("flat top"),
+    /// * The center of the hex grid with index `(0, 0)` is located at `[0.0, 0.0]`.
     #[inline]
     pub fn center_in_world_col(&self, grid_size: &TilemapGridSize) -> Vec2 {
         Self::project_col(Vec2::new(self.q as f32, self.r as f32), grid_size)
@@ -315,8 +316,9 @@ impl AxialPos {
 
     /// Returns the coordinate of the corner of a hex tile in the specified `corner_direction`,
     /// in world space, assuming that:
-    ///     1) tiles are col-oriented ("flat top"),
-    ///     2) the center of the hex_grid with index `(0, 0)` is located at `[0.0, 0.0]`.
+    ///
+    /// * Tiles are column-oriented ("flat top"),
+    /// * The center of the hex grid with index `(0, 0)` is located at `[0.0, 0.0]`.
     #[inline]
     pub fn corner_in_world_col(
         &self,
@@ -331,9 +333,10 @@ impl AxialPos {
         Self::project_col(center + corner_pos, grid_size)
     }
 
-    /// Returns the axial position of the hex_grid containing the given world position, assuming that:
-    ///     1) tiles are row-oriented ("pointy top") and that
-    ///     2) the world position corresponding to `[0.0, 0.0]` lies in the hex_grid indexed `(0, 0)`.
+    /// Returns the axial position of the hex grid containing the given world position, assuming that:
+    ///
+    /// * Tiles are row-oriented ("pointy top") and that
+    /// * The world position corresponding to `[0.0, 0.0]` lies on the hex grid at index `(0, 0)`.
     #[inline]
     pub fn from_world_pos_row(world_pos: &Vec2, grid_size: &TilemapGridSize) -> AxialPos {
         let normalized_world_pos = Vec2::new(
@@ -344,9 +347,10 @@ impl AxialPos {
         frac_pos.round()
     }
 
-    /// Returns the axial position of the hex_grid containing the given world position, assuming that:
-    ///     1) tiles are column-oriented ("flat top") and that
-    ///     2) the world position corresponding to `[0.0, 0.0]` lies in the hex_grid indexed `(0, 0)`.
+    /// Returns the axial position of the hex grid containing the given world position, assuming that:
+    ///
+    /// * Tiles are column-oriented ("flat top") and that
+    /// * The world position corresponding to `[0.0, 0.0]` lies on the hex grid at index `(0, 0)`.
     #[inline]
     pub fn from_world_pos_col(world_pos: &Vec2, grid_size: &TilemapGridSize) -> AxialPos {
         let normalized_world_pos = Vec2::new(

--- a/src/helpers/hex_grid/consts.rs
+++ b/src/helpers/hex_grid/consts.rs
@@ -1,4 +1,4 @@
-//! Various constants that are helpful for hex_grid-grid related calculations.
+//! Various constants that are helpful for hex grid related calculations.
 
 /// sqrt(3)
 pub const SQRT_3: f32 = 1.7320508;

--- a/src/helpers/hex_grid/cube.rs
+++ b/src/helpers/hex_grid/cube.rs
@@ -6,7 +6,7 @@ use std::ops::{Add, Mul, Sub};
 /// Identical to [`AxialPos`], but has an extra component `s`. Together, `q`, `r`, `s`
 /// satisfy the identity: `q + r + s = 0`.
 ///
-/// It is vector-like. In others: two `AxialPos` can be added/subtracted, and it can be multiplied
+/// It is vector-like. In other words: two `AxialPos` can be added/subtracted, and it can be multiplied
 /// by an `i32` scalar.
 ///
 /// It can be converted from/into to [`AxialPos`].
@@ -92,7 +92,7 @@ impl Mul<CubePos> for u32 {
 }
 
 impl CubePos {
-    /// The magnitude of a cube position is its distance away from the `[0, 0, 0]` hex_grid.
+    /// The magnitude of a cube position is its distance away from `[0, 0, 0]` in the cube grid.
     ///
     /// See the Red Blob Games article for a [helpful interactive diagram](https://www.redblobgames.com/grids/hexagons/#distances-cube).
     #[inline]
@@ -100,7 +100,7 @@ impl CubePos {
         self.q.abs().max(self.r.abs().max(self.s.abs()))
     }
 
-    /// Returns the hex_grid distance between `self` and `other`.
+    /// Returns the distance between `self` and `other` in the cube grid.
     #[inline]
     pub fn distance_from(&self, other: &CubePos) -> i32 {
         let cube_pos: CubePos = *self - *other;

--- a/src/helpers/hex_grid/neighbors.rs
+++ b/src/helpers/hex_grid/neighbors.rs
@@ -438,7 +438,7 @@ impl HexNeighbors<TilePos> {
     /// Returns neighboring tile positions. This works for maps using [`HexCoordSystem::Row`] and
     /// [`HexCoordSystem::Column`].
     ///
-    /// For maps using [`HexCoordSystem::RowEven`], [`HexCoordSystem::ColEven`],
+    /// For maps using [`HexCoordSystem::RowEven`], [`HexCoordSystem::ColumnEven`],
     /// [`HexCoordSystem::RowOdd`], [`HexCoordSystem::RowOdd`], use one of:
     ///     * [`HexNeighbors::get_neighboring_positions_row_even`]
     ///     * [`HexNeighbors::get_neighboring_positions_row_odd`]
@@ -495,7 +495,7 @@ impl HexNeighbors<TilePos> {
         HexNeighbors::from_directional_closure(f)
     }
 
-    /// Returns neighboring tile positions on a map using [`HexCoordSystem::ColEven`].
+    /// Returns neighboring tile positions on a map using [`HexCoordSystem::ColumnEven`].
     ///
     /// A tile position will be `None` for a particular direction, if that neighbor would not lie
     /// on the map.
@@ -511,7 +511,7 @@ impl HexNeighbors<TilePos> {
         HexNeighbors::from_directional_closure(f)
     }
 
-    /// Returns neighboring tile positions on a map using [`HexCoordSystem::ColOdd`].
+    /// Returns neighboring tile positions on a map using [`HexCoordSystem::ColumnOdd`].
     ///
     /// A tile position will be `None` for a particular direction, if that neighbor would not lie
     /// on the map.

--- a/src/helpers/square_grid/diamond.rs
+++ b/src/helpers/square_grid/diamond.rs
@@ -11,7 +11,7 @@ use std::ops::{Add, Mul, Sub};
 /// Position for tiles arranged in [`Diamond`](crate::map::IsoCoordSystem::Diamond) isometric
 /// coordinate system.
 ///
-/// It is a vector-like. In other words: it makes sense to add and subtract
+/// It is vector-like. In other words: it makes sense to add and subtract
 /// two `DiamondPos`, and it makes sense to multiply a `DiamondPos` by
 /// an [`i32`](i32) scalar.
 ///

--- a/src/helpers/square_grid/diamond.rs
+++ b/src/helpers/square_grid/diamond.rs
@@ -125,8 +125,10 @@ impl DiamondPos {
     /// Project a vector representing a fractional tile position (i.e. the components can be `f32`)
     /// into world space.
     ///
-    /// This is a helper function for [`center_in_world`], [`corner_offset_in_world`] and
-    /// [`corner_in_world`].
+    /// This is a helper function for
+    /// [`center_in_world`](Self::center_in_world),
+    /// [`corner_offset_in_world`](Self::corner_offset_in_world) and
+    /// [`corner_in_world`](Self::corner_in_world).
     #[inline]
     pub fn project(pos: Vec2, grid_size: &TilemapGridSize) -> Vec2 {
         let unscaled_pos = DIAMOND_BASIS * pos;

--- a/src/helpers/square_grid/mod.rs
+++ b/src/helpers/square_grid/mod.rs
@@ -12,7 +12,7 @@ use std::ops::{Add, Mul, Sub};
 
 /// Position for tiles arranged in a square coordinate system.
 ///
-/// It is a vector-like. In other words: it makes sense to add and subtract
+/// It is vector-like. In other words: it makes sense to add and subtract
 /// two `SquarePos`, and it makes sense to multiply a `SquarePos` by
 /// an [`i32`](i32) scalar.
 ///

--- a/src/helpers/square_grid/mod.rs
+++ b/src/helpers/square_grid/mod.rs
@@ -10,7 +10,7 @@ use crate::{TilemapGridSize, TilemapSize};
 use bevy::math::Vec2;
 use std::ops::{Add, Mul, Sub};
 
-/// Position for tiles arranged in [`Square`](crate::map::IsoCoordSystem::Square) coordinate system.
+/// Position for tiles arranged in a square coordinate system.
 ///
 /// It is a vector-like. In other words: it makes sense to add and subtract
 /// two `SquarePos`, and it makes sense to multiply a `SquarePos` by
@@ -103,8 +103,10 @@ impl SquarePos {
     /// Project a vector representing a fractional tile position (i.e. the components can be `f32`)
     /// into world space.
     ///
-    /// This is a helper function for [`center_in_world`], [`corner_offset_in_world`] and
-    /// [`corner_in_world`].
+    /// This is a helper function for
+    /// [`center_in_world`](Self::center_in_world),
+    /// [`corner_offset_in_world`](Self::corner_offset_in_world) and
+    /// [`corner_in_world`](Self::corner_in_world).
     #[inline]
     pub fn project(pos: Vec2, grid_size: &TilemapGridSize) -> Vec2 {
         Vec2::new(grid_size.x * pos.x, grid_size.y * pos.y)

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -315,7 +315,7 @@ impl From<TilemapTileSize> for TilemapTextureSize {
     }
 }
 
-/// Different hex_grid coordinate systems. You can find out more at this link: <https://www.redblobgames.com/grids/hexagons/>
+/// Different hex grid coordinate systems. You can find out more at this link: <https://www.redblobgames.com/grids/hexagons/>
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, FromReflect)]
 pub enum HexCoordSystem {
     RowEven,


### PR DESCRIPTION
While building docs locally, I noticed a good amount of warnings spewing forth about broken doc links.

This adds `cargo doc` to CI and fixes all of the warnings.

This also does some small drive-by formatting/grammar fixes to docs located nearby the lines generating those warnings.

This doesn't add any requirements for docs, just validates existing docs.