### PR TITLE
Fix comment explaining a system

### DIFF
--- a/examples/hex_neighbors.rs
+++ b/examples/hex_neighbors.rs
@@ -328,7 +328,7 @@ fn hover_highlight_tile_label(
 #[derive(Component)]
 struct NeighborHighlight;
 
-// Swaps the map type, when user presses SPACE
+// Highlight neighbor tiles of hovered tile
 #[allow(clippy::too_many_arguments)]
 fn highlight_neighbor_label(
     mut commands: Commands,


### PR DESCRIPTION
The comment that was explaining system that highlights neighbors was the same as of the system that swaps tilemap type