### PR TITLE
Update Tiled crate and related example to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ ldtk_rust = { version = "0.6" }
 rand = "0.8"
 env_logger = "0.9"
 serde_json = { version = "1.0" }
-tiled = { version = "0.10.2", default-features = false }
+tiled = { version = "0.11.0", default-features = false }
 
 [dev-dependencies.bevy]
 version = "0.10"


### PR DESCRIPTION
- Updated the Tiled crate to 0.11.0.
- Creates BytesResourceReader and implemented the ResourceReader trait for the new tiled::Loader behaviour.
- Renames TileLayer to Tiles.