### PR TITLE
Add support for TSX tilesets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ bevy = { version = "0.10", default-features = false, features = [
     "bevy_asset",
     "bevy_sprite",
 ] }
+
+futures-lite = "1.13.0"
 log = "0.4"
 regex = "1.5.4"
 


### PR DESCRIPTION
Workaround to support Tiles TSX tilesets files. When a TSX file extension is encountered in read_from that file will be read from the path and the bytes ignored.

Bevy gives a byte stream to the TMX file, when Tiled comes across a TSX dependency from that file it will try and read it from the same stream which results in the same TMX file being read. The Tiled crate does not yet support loading child dependencies separately.

Some discussion where I initially queried this as a bug, it was mentioned that Tiled may at some point be updated with Bevy in mind, until then we have this workaround. Works locally and I can access custom tile properties from the TSX tileset.

https://github.com/mapeditor/rs-tiled/issues/265#issuecomment-1537424140