### PR TITLE
Track changed Image assets and use them to update image caches.

### DIFF
--- a/src/render/material.rs
+++ b/src/render/material.rs
@@ -31,7 +31,7 @@ use super::{
     draw::DrawTilemapMaterial,
     pipeline::{TilemapPipeline, TilemapPipelineKey},
     queue::{ImageBindGroups, TilemapViewBindGroup},
-    ModifiedImageHandles, RenderYSort,
+    ModifiedImageIds, RenderYSort,
 };
 
 #[cfg(not(feature = "atlas"))]
@@ -489,7 +489,7 @@ pub fn bind_material_tilemap_meshes<M: MaterialTilemap>(
     (standard_tilemap_meshes, materials): (Query<(&ChunkId, &TilemapId)>, Query<&Handle<M>>),
     mut views: Query<(Entity, &VisibleEntities)>,
     render_materials: Res<RenderMaterialsTilemap<M>>,
-    modified_image_handles: Res<ModifiedImageHandles>,
+    modified_image_ids: Res<ModifiedImageIds>,
     #[cfg(not(feature = "atlas"))] (mut texture_array_cache, render_queue): (
         ResMut<TextureArrayCache>,
         Res<RenderQueue>,
@@ -580,7 +580,7 @@ pub fn bind_material_tilemap_meshes<M: MaterialTilemap>(
                             ],
                         )
                     };
-                    if modified_image_handles.is_texture_modified(&chunk.texture) {
+                    if modified_image_ids.is_texture_modified(&chunk.texture) {
                         image_bind_groups
                             .values
                             .insert(chunk.texture.clone_weak(), create_bind_group());

--- a/src/render/texture_array_cache.rs
+++ b/src/render/texture_array_cache.rs
@@ -17,7 +17,7 @@ use bevy::{
     utils::{HashMap, HashSet},
 };
 
-use super::ModifiedImageHandles;
+use super::ModifiedImageIds;
 
 #[derive(Resource, Default, Debug, Clone)]
 pub struct TextureArrayCache {
@@ -342,15 +342,15 @@ impl TextureArrayCache {
     }
 }
 
-// A system to remove any modified textures from the TextureArrayCache. Modified images will be
-// added back to the pipeline, and so will be reloaded. This allows the TextureArrayCache to be
-// responsive to hot-reloading, for example.
+/// A system to remove any modified textures from the TextureArrayCache. Modified images will be
+/// added back to the pipeline, and so will be reloaded. This allows the TextureArrayCache to be
+/// responsive to hot-reloading, for example.
 pub fn remove_modified_textures(
-    modified_image_handles: Res<ModifiedImageHandles>,
+    modified_image_ids: Res<ModifiedImageIds>,
     mut texture_cache: ResMut<TextureArrayCache>,
 ) {
     let texture_is_unmodified =
-        |texture: &TilemapTexture| !modified_image_handles.is_texture_modified(texture);
+        |texture: &TilemapTexture| !modified_image_ids.is_texture_modified(texture);
 
     texture_cache
         .textures

--- a/src/render/texture_array_cache.rs
+++ b/src/render/texture_array_cache.rs
@@ -1,7 +1,7 @@
 use crate::render::extract::ExtractedTilemapTexture;
 use crate::{TilemapSpacing, TilemapTexture, TilemapTextureSize, TilemapTileSize};
 use bevy::asset::Assets;
-use bevy::prelude::Resource;
+use bevy::prelude::{ResMut, Resource};
 use bevy::{
     prelude::{Image, Res},
     render::{
@@ -16,6 +16,8 @@ use bevy::{
     },
     utils::{HashMap, HashSet},
 };
+
+use super::ModifiedImageHandles;
 
 #[derive(Resource, Default, Debug, Clone)]
 pub struct TextureArrayCache {
@@ -338,4 +340,25 @@ impl TextureArrayCache {
             }
         }
     }
+}
+
+// A system to remove any modified textures from the TextureArrayCache. Modified images will be
+// added back to the pipeline, and so will be reloaded. This allows the TextureArrayCache to be
+// responsive to hot-reloading, for example.
+pub fn remove_modified_textures(
+    modified_image_handles: Res<ModifiedImageHandles>,
+    mut texture_cache: ResMut<TextureArrayCache>,
+) {
+    let texture_is_unmodified =
+        |texture: &TilemapTexture| !modified_image_handles.is_texture_modified(texture);
+
+    texture_cache
+        .textures
+        .retain(|texture, _| texture_is_unmodified(texture));
+    texture_cache
+        .meta_data
+        .retain(|texture, _| texture_is_unmodified(texture));
+    texture_cache.prepare_queue.retain(texture_is_unmodified);
+    texture_cache.queue_queue.retain(texture_is_unmodified);
+    texture_cache.bad_flag_queue.retain(texture_is_unmodified);
 }


### PR DESCRIPTION
Previously, since the bind groups do not get updated every frame, modified image assets would not be rebound. This caused hot reloading to no longer work. Similarly, the TextureArrayCache (when not using atlas) would not invalidate modified assets, so the textures would become out-of-date.

Note there can be other reasons that an asset can be modified, so this should keep the assets more up-to-date in general.

Fixes #430.