### PR TITLE
Fixed error in chunking example

### DIFF
--- a/examples/chunking.rs
+++ b/examples/chunking.rs
@@ -54,10 +54,10 @@ fn startup(mut commands: Commands) {
 }
 
 fn camera_pos_to_chunk_pos(camera_pos: &Vec2) -> IVec2 {
-    let camera_pos = camera_pos.as_ivec2();
-    let chunk_size: IVec2 = IVec2::new(CHUNK_SIZE.x as i32, CHUNK_SIZE.y as i32);
-    let tile_size: IVec2 = IVec2::new(TILE_SIZE.x as i32, TILE_SIZE.y as i32);
-    camera_pos / (chunk_size * tile_size)
+    let camera_pos = camera_pos.floor();
+    let chunk_size: Vec2 = Vec2::new(CHUNK_SIZE.x as f32, CHUNK_SIZE.y as f32);
+    let tile_size: Vec2 = TILE_SIZE.into();
+    (camera_pos / (chunk_size * tile_size)).floor().as_ivec2()
 }
 
 fn spawn_chunks_around_camera(


### PR DESCRIPTION
When converting a f32 to an i32 it gets rounded to the integer value that is the next closest to zero.
Meaning both [0.5, 0.5] and [-0.5, -0.5] would be rounded to [0, 0].
In the example, the [0, 0] chunk was actually four times as large and the chunks did not update when moving in range -1..1