### PR TITLE
Derive `FromReflect` for `TileTextureIndex` and more

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,12 @@
 //! - Built in animation support  – see [`animation` example](https://github.com/StarArawn/bevy_ecs_tilemap/blob/main/examples/animation.rs).
 //! - Texture array support.
 
-use bevy::prelude::{
-    Bundle, Changed, Component, ComputedVisibility, CoreSet, Deref, GlobalTransform,
-    IntoSystemConfig, Plugin, Query, Reflect, ReflectComponent, Transform, Visibility,
+use bevy::{
+    prelude::{
+        Bundle, Changed, Component, ComputedVisibility, CoreSet, Deref, GlobalTransform,
+        IntoSystemConfig, Plugin, Query, Reflect, ReflectComponent, Transform, Visibility,
+    },
+    reflect::FromReflect,
 };
 use map::{
     TilemapGridSize, TilemapSize, TilemapSpacing, TilemapTexture, TilemapTextureSize,
@@ -84,7 +87,7 @@ impl Plugin for TilemapPlugin {
     }
 }
 
-#[derive(Component, Reflect, Debug, Clone, Copy, Deref)]
+#[derive(Component, Reflect, Debug, Clone, Copy, Deref, FromReflect)]
 #[reflect(Component)]
 pub struct FrustumCulling(pub bool);
 

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -40,7 +40,7 @@ pub struct TilemapRenderSettings {
 }
 
 /// A component which stores a reference to the tilemap entity.
-#[derive(Component, Reflect, Clone, Copy, Debug, Hash)]
+#[derive(Component, Reflect, Clone, Copy, Debug, Hash, FromReflect)]
 #[reflect(Component)]
 pub struct TilemapId(pub Entity);
 
@@ -51,7 +51,7 @@ impl Default for TilemapId {
 }
 
 /// Size of the tilemap in tiles.
-#[derive(Component, Reflect, Default, Clone, Copy, Debug, Hash)]
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, Hash, FromReflect)]
 #[reflect(Component)]
 pub struct TilemapSize {
     pub x: u32,
@@ -88,7 +88,7 @@ impl From<UVec2> for TilemapSize {
     }
 }
 
-#[derive(Component, Reflect, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Component, Reflect, Clone, Debug, Hash, PartialEq, Eq, FromReflect)]
 #[reflect(Component)]
 pub enum TilemapTexture {
     /// All textures for tiles are inside a single image asset.
@@ -194,7 +194,7 @@ impl TilemapTexture {
 }
 
 /// Size of the tiles in pixels
-#[derive(Component, Reflect, Default, Clone, Copy, Debug, PartialOrd, PartialEq)]
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, PartialOrd, PartialEq, FromReflect)]
 #[reflect(Component)]
 pub struct TilemapTileSize {
     pub x: f32,
@@ -233,7 +233,7 @@ impl From<Vec2> for TilemapTileSize {
 /// This can be used to overlay tiles on top of each other.
 /// Ex. A 16x16 pixel tile can be overlapped by 8 pixels by using
 /// a grid size of 16x8.
-#[derive(Component, Reflect, Default, Clone, Copy, Debug, PartialOrd, PartialEq)]
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, PartialOrd, PartialEq, FromReflect)]
 #[reflect(Component)]
 pub struct TilemapGridSize {
     pub x: f32,
@@ -266,7 +266,7 @@ impl From<&Vec2> for TilemapGridSize {
 
 /// Spacing between tiles in pixels inside of the texture atlas.
 /// Defaults to 0.0
-#[derive(Component, Reflect, Default, Clone, Copy, Debug)]
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, FromReflect)]
 #[reflect(Component)]
 pub struct TilemapSpacing {
     pub x: f32,
@@ -286,7 +286,7 @@ impl TilemapSpacing {
 }
 
 /// Size of the atlas texture in pixels.
-#[derive(Component, Reflect, Default, Clone, Copy, Debug)]
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, FromReflect)]
 #[reflect(Component)]
 pub struct TilemapTextureSize {
     pub x: f32,
@@ -334,7 +334,7 @@ pub enum IsoCoordSystem {
 }
 
 /// The type of tile to be rendered, currently we support: Square, Hex, and Isometric.
-#[derive(Component, Reflect, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Component, Reflect, Debug, Clone, Copy, PartialEq, Eq, Hash, FromReflect)]
 #[reflect(Component)]
 pub enum TilemapType {
     /// A tilemap with rectangular tiles.

--- a/src/tiles/mod.rs
+++ b/src/tiles/mod.rs
@@ -67,7 +67,7 @@ impl From<&TilePos> for Vec2 {
 }
 
 /// A texture index into the atlas or texture array for a single tile. Indices in an atlas are horizontal based.
-#[derive(Component, Reflect, Default, Clone, Copy, Debug, Hash)]
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, Hash, FromReflect)]
 #[reflect(Component)]
 pub struct TileTextureIndex(pub u32);
 

--- a/src/tiles/mod.rs
+++ b/src/tiles/mod.rs
@@ -72,7 +72,7 @@ impl From<&TilePos> for Vec2 {
 pub struct TileTextureIndex(pub u32);
 
 /// A custom color for the tile.
-#[derive(Component, Reflect, Default, Clone, Copy, Debug)]
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, FromReflect)]
 #[reflect(Component)]
 pub struct TileColor(pub Color);
 
@@ -83,7 +83,7 @@ impl From<Color> for TileColor {
 }
 
 /// Hides or shows a tile based on the boolean. Default: True
-#[derive(Component, Reflect, Clone, Copy, Debug, Hash)]
+#[derive(Component, Reflect, Clone, Copy, Debug, Hash, FromReflect)]
 #[reflect(Component)]
 pub struct TileVisible(pub bool);
 
@@ -94,7 +94,7 @@ impl Default for TileVisible {
 }
 
 /// Flips the tiles texture along the X, Y or diagonal axes
-#[derive(Component, Reflect, Default, Clone, Copy, Debug, Hash)]
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, Hash, FromReflect)]
 #[reflect(Component)]
 pub struct TileFlip {
     /// Flip tile along the x axis.
@@ -116,14 +116,14 @@ pub struct TileBundle {
     pub old_position: TilePosOld,
 }
 
-#[derive(Component, Reflect, Default, Clone, Copy, Debug)]
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, FromReflect)]
 #[reflect(Component)]
 pub struct TilePosOld(pub TilePos);
 
 /// A component that is attached to a Tile entity that
 /// tells the GPU how to animate the tile.
 /// Currently all frames must be aligned in your tilemap.
-#[derive(Component, Reflect, Clone, Copy, Debug)]
+#[derive(Component, Reflect, Clone, Copy, Debug, FromReflect)]
 pub struct AnimatedTile {
     /// The start frame index in the tilemap atlas/array (inclusive).
     pub start: u32,

--- a/src/tiles/storage.rs
+++ b/src/tiles/storage.rs
@@ -6,7 +6,7 @@ use super::TilePos;
 
 /// Used to store tile entities for fast look up.
 /// Tile entities are stored in a grid. The grid is always filled with None.
-#[derive(Component, Reflect, Default, Debug, Clone)]
+#[derive(Component, Reflect, Default, Debug, Clone, FromReflect)]
 #[reflect(Component)]
 pub struct TileStorage {
     tiles: Vec<Option<Entity>>,


### PR DESCRIPTION
Pretty self-explanatory.

I required `TileTextureIndex` to implement `FromReflect`, as I was using it with `bevy_proto`, which requires it for turning components into `Schematic`s.

While I was at it, I also derived `FromReflect` for other types that implemented `Component` and `Reflect`, since it makes sense for most components on entities to be reflectable.