### PR TITLE
Fix Rust 1.71 lints

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -140,7 +140,7 @@ fn main() {
                 .set(ImagePlugin::default_nearest()),
         )
         .add_plugins(LogDiagnosticsPlugin::default())
-        .add_plugins(FrameTimeDiagnosticsPlugin::default())
+        .add_plugins(FrameTimeDiagnosticsPlugin)
         .add_plugins(TilemapPlugin)
         .add_systems(Startup, startup)
         .add_systems(Startup, create_background)

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -57,7 +57,7 @@ fn main() {
             ..Default::default()
         })
         .add_plugins(LogDiagnosticsPlugin::default())
-        .add_plugins(FrameTimeDiagnosticsPlugin::default())
+        .add_plugins(FrameTimeDiagnosticsPlugin)
         .add_plugins(TilemapPlugin)
         .add_systems(Startup, startup)
         .add_systems(Update, helpers::camera::movement)

--- a/examples/hex_neighbors.rs
+++ b/examples/hex_neighbors.rs
@@ -287,7 +287,7 @@ fn hover_highlight_tile_label(
     for highlighted_tile_entity in highlighted_tiles_q.iter() {
         if let Ok(label) = tile_label_q.get(highlighted_tile_entity) {
             if let Ok(mut tile_text) = text_q.get_mut(label.0) {
-                for mut section in tile_text.sections.iter_mut() {
+                for section in tile_text.sections.iter_mut() {
                     section.style.color = Color::BLACK;
                 }
                 commands.entity(highlighted_tile_entity).remove::<Hovered>();
@@ -314,7 +314,7 @@ fn hover_highlight_tile_label(
             if let Some(tile_entity) = tile_storage.get(&tile_pos) {
                 if let Ok(label) = tile_label_q.get(tile_entity) {
                     if let Ok(mut tile_text) = text_q.get_mut(label.0) {
-                        for mut section in tile_text.sections.iter_mut() {
+                        for section in tile_text.sections.iter_mut() {
                             section.style.color = Color::RED;
                         }
                         commands.entity(tile_entity).insert(Hovered);
@@ -343,7 +343,7 @@ fn highlight_neighbor_label(
     for highlighted_tile_entity in highlighted_tiles_q.iter() {
         if let Ok(label) = tile_label_q.get(highlighted_tile_entity) {
             if let Ok(mut tile_text) = text_q.get_mut(label.0) {
-                for mut section in tile_text.sections.iter_mut() {
+                for section in tile_text.sections.iter_mut() {
                     section.style.color = Color::BLACK;
                 }
                 commands
@@ -370,7 +370,7 @@ fn highlight_neighbor_label(
                 if let Some(tile_entity) = tile_storage.checked_get(neighbor_pos) {
                     if let Ok(label) = tile_label_q.get(tile_entity) {
                         if let Ok(mut tile_text) = text_q.get_mut(label.0) {
-                            for mut section in tile_text.sections.iter_mut() {
+                            for section in tile_text.sections.iter_mut() {
                                 section.style.color = Color::BLUE;
                             }
                             commands.entity(tile_entity).insert(NeighborHighlight);
@@ -411,7 +411,7 @@ fn highlight_neighbor_label(
                 if let Some(tile_entity) = tile_storage.checked_get(&tile_pos) {
                     if let Ok(label) = tile_label_q.get(tile_entity) {
                         if let Ok(mut tile_text) = text_q.get_mut(label.0) {
-                            for mut section in tile_text.sections.iter_mut() {
+                            for section in tile_text.sections.iter_mut() {
                                 section.style.color = Color::GREEN;
                             }
                             commands.entity(tile_entity).insert(NeighborHighlight);

--- a/examples/hex_neighbors_radius_chunks.rs
+++ b/examples/hex_neighbors_radius_chunks.rs
@@ -408,7 +408,7 @@ fn hover_highlight_tile_label(
     for highlighted_tile_entity in highlighted_tiles_q.iter() {
         if let Ok(label) = tile_label_q.get(highlighted_tile_entity) {
             if let Ok(mut tile_text) = text_q.get_mut(label.0) {
-                for mut section in tile_text.sections.iter_mut() {
+                for section in tile_text.sections.iter_mut() {
                     section.style.color = Color::BLACK;
                 }
                 commands.entity(highlighted_tile_entity).remove::<Hovered>();
@@ -429,7 +429,7 @@ fn hover_highlight_tile_label(
             if let Some(tile_entity) = tile_storage.get(&tile_pos) {
                 if let Ok(label) = tile_label_q.get(tile_entity) {
                     if let Ok(mut tile_text) = text_q.get_mut(label.0) {
-                        for mut section in tile_text.sections.iter_mut() {
+                        for section in tile_text.sections.iter_mut() {
                             section.style.color = Color::RED;
                         }
                         commands.entity(tile_entity).insert(Hovered);
@@ -474,7 +474,7 @@ fn highlight_neighbor_labels(
     for highlighted_tile_entity in highlighted_tiles_q.iter() {
         if let Ok(label) = tile_label_q.get(highlighted_tile_entity) {
             if let Ok(mut tile_text) = text_q.get_mut(label.0) {
-                for mut section in tile_text.sections.iter_mut() {
+                for section in tile_text.sections.iter_mut() {
                     section.style.color = Color::BLACK;
                 }
                 commands
@@ -510,7 +510,7 @@ fn highlight_neighbor_labels(
                     if neighbors.contains(&tile_hex_pos) {
                         if let Ok(label) = tile_label_q.get(*tile_entity) {
                             if let Ok(mut tile_text) = text_q.get_mut(label.0) {
-                                for mut section in tile_text.sections.iter_mut() {
+                                for section in tile_text.sections.iter_mut() {
                                     section.style.color = Color::BLUE;
                                 }
                                 commands.entity(*tile_entity).insert(NeighborHighlight);

--- a/examples/mouse_to_tile.rs
+++ b/examples/mouse_to_tile.rs
@@ -330,7 +330,7 @@ fn highlight_tile_labels(
     for highlighted_tile_entity in highlighted_tiles_q.iter() {
         if let Ok(label) = tile_label_q.get(highlighted_tile_entity) {
             if let Ok(mut tile_text) = text_q.get_mut(label.0) {
-                for mut section in tile_text.sections.iter_mut() {
+                for section in tile_text.sections.iter_mut() {
                     section.style.color = Color::BLACK;
                 }
                 commands
@@ -359,7 +359,7 @@ fn highlight_tile_labels(
             if let Some(tile_entity) = tile_storage.get(&tile_pos) {
                 if let Ok(label) = tile_label_q.get(tile_entity) {
                     if let Ok(mut tile_text) = text_q.get_mut(label.0) {
-                        for mut section in tile_text.sections.iter_mut() {
+                        for section in tile_text.sections.iter_mut() {
                             section.style.color = Color::RED;
                         }
                         commands.entity(tile_entity).insert(HighlightedLabel);

--- a/examples/random_map.rs
+++ b/examples/random_map.rs
@@ -81,7 +81,7 @@ fn main() {
                 .set(ImagePlugin::default_nearest()),
         )
         .add_plugins(LogDiagnosticsPlugin::default())
-        .add_plugins(FrameTimeDiagnosticsPlugin::default())
+        .add_plugins(FrameTimeDiagnosticsPlugin)
         .add_plugins(TilemapPlugin)
         .add_systems(Startup, startup)
         .add_systems(Update, helpers::camera::movement)

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -168,7 +168,7 @@ impl TilemapTexture {
                     .usage
                     .contains(TextureUsages::COPY_SRC)
                 {
-                    if let Some(mut image) = images.get_mut(handle) {
+                    if let Some(image) = images.get_mut(handle) {
                         image.texture_descriptor.usage = TextureUsages::TEXTURE_BINDING
                             | TextureUsages::COPY_SRC
                             | TextureUsages::COPY_DST;


### PR DESCRIPTION
New clippy lint

https://rust-lang.github.io/rust-clippy/master/index.html#/default_constructed_unit_structs

And seemingly, more cases unused `mut` are now detected.

https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unused-mut