### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,83 +11,71 @@ name: Continuous Integration
 jobs:
   check:
     name: Run cargo check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run cargo check
+        run: cargo check --all-targets
+
+      - name: Run cargo check with atlas feature
+        run: cargo check --all-targets --features atlas
+
+      - name: Run cargo check headless
+        run: cargo check --all-targets --no-default-features
+
+  docs:
+    name: Run cargo doc
     env:
       RUSTDOCFLAGS: -D warnings
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets
-
-      # Clean between builds to avoid disk space issues.
-      - name: Cargo Clean
-        uses: "actions-rs/cargo@v1"
-        with:
-          command: clean
-
-      - name: Run cargo check feature atlas
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets --features atlas
-
-      - name: Run cargo check headless
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets --no-default-features
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --all-features --no-deps
-
-  #   test:
-  #     name: Tests
-  #     strategy:
-  #       # Tests are most likely to have OS-specific behavior
-  #       matrix:
-  #         os: [ubuntu-latest, windows-latest, macOS-latest]
-
-  #     runs-on: ${{ matrix.os }}
-  #     steps:
-  #       - name: Checkout sources
-  #         uses: actions/checkout@v2
-
-  #       - name: Install stable toolchain
-  #         uses: actions-rs/toolchain@v1
-  #         with:
-  #           profile: minimal
-  #           toolchain: stable
-  #           override: true
-
-  #       - name: Run cargo test
-  #         uses: actions-rs/cargo@v1
-  #         with:
-  #           command: test
+        run: cargo doc --all-features --no-deps
 
   build_examples:
     name: Build examples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - run: cargo build --examples
-      - run: cargo clean 
-      - run: cargo build --examples --features atlas
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build examples
+        run: cargo build --examples
+
+      - name: Clean
+        run: cargo clean
+
+      - name: Build examples with atlas feature
+        run: cargo build --examples --features atlas
+
+  test:
+    name: Tests
+    strategy:
+      # Tests are most likely to have OS-specific behavior
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run cargo test
+        run: cargo test

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,53 +1,39 @@
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 name: Code Quality
 
 jobs:
   quality:
     name: Formatting
-        
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
+          components: rustfmt
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check 
+        run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-      
+        uses: actions/checkout@v3
+
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          
-      - name: Add clippy
-        run: rustup component add clippy
-        
+          components: clippy
+
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --no-deps --examples -- -D warnings
-          
+        run: cargo clippy --no-deps --examples -- -D warnings


### PR DESCRIPTION
Updates `actions/checkout` to `v3` and switches to `dtolnay/rust-toolchain` from the unmaintained `actions-rs/toolchain`.

This also enables tests.

- Fixes node version warnings in CI
- Seemingly fixes disk space error in CI

~~Note: Clippy is failing due to new lints in Rust 1.71. See #443 .~~
