### PR TITLE
Add `license = "MIT"` field to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.11.0"
 authors = ["John Mitchell"]
 homepage = "https://github.com/StarArawn/bevy_ecs_tilemap"
 repository = "https://github.com/StarArawn/bevy_ecs_tilemap"
+license = "MIT"
 license-file = "LICENSE"
 edition = "2021"
 exclude = ["assets/*", "screenshots/*"]


### PR DESCRIPTION
This PR adds a `license = "MIT"` field to `Cargo.toml`. 

This does not change the license of `bevy_ecs_tilemap` - it is still the MIT license. However, this allows tools (such as `crates.io` or [`cargo-license`](https://crates.io/crates/cargo-license)) to better recognize the license used by this crate.

For example, currently `crates.io` cites this crate has having a non-standard license, as only `license-file` is specified and `crates.io` cannot detect if the file is indeed the MIT license. With this change, `crates.io` can (upon the next published update) detect that the license is indeed the MIT license.

----

P.S. I left the `license-file` field in because, according to [the manifest format documentation for the `include` field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields):

> The following files are always included:
>
> * If a [`license-file`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields) is specified, it is always included.

and it is not otherwise clear if `LICENSE` would be included without some additional tinkering to `Cargo.toml`. As I am not sure if it's desired for the `LICENSE` file to be distributed, and it's unlikely that having both `license` and `license-file` would be considered an issue, I am taking the safe route - I am leaving the `license-file` field in.