### PR TITLE
Implement `From<TilePos>` for `CubePos`

### DIFF
--- a/src/helpers/hex_grid/axial.rs
+++ b/src/helpers/hex_grid/axial.rs
@@ -35,12 +35,18 @@ pub struct AxialPos {
     pub r: i32,
 }
 
-impl From<&TilePos> for AxialPos {
-    fn from(tile_pos: &TilePos) -> Self {
+impl From<TilePos> for AxialPos {
+    fn from(tile_pos: TilePos) -> Self {
         AxialPos {
             q: tile_pos.x as i32,
             r: tile_pos.y as i32,
         }
+    }
+}
+
+impl From<&TilePos> for AxialPos {
+    fn from(tile_pos: &TilePos) -> Self {
+        AxialPos::from(*tile_pos)
     }
 }
 

--- a/src/helpers/hex_grid/cube.rs
+++ b/src/helpers/hex_grid/cube.rs
@@ -1,6 +1,9 @@
 //! Code for the cube coordinate system
 
-use crate::helpers::hex_grid::axial::{AxialPos, FractionalAxialPos};
+use crate::{
+    helpers::hex_grid::axial::{AxialPos, FractionalAxialPos},
+    tiles::TilePos,
+};
 use std::ops::{Add, Mul, Sub};
 
 /// Identical to [`AxialPos`], but has an extra component `s`. Together, `q`, `r`, `s`
@@ -28,6 +31,13 @@ impl From<AxialPos> for CubePos {
     fn from(axial_pos: AxialPos) -> Self {
         let AxialPos { q, r } = axial_pos;
         CubePos { q, r, s: -(q + r) }
+    }
+}
+
+impl From<TilePos> for CubePos {
+    #[inline]
+    fn from(tile_pos: TilePos) -> Self {
+        AxialPos::from(tile_pos).into()
     }
 }
 


### PR DESCRIPTION
This PR just adds an API converting directly from a `TilePos` to a `CubePos` without having to go through an intermediate `AxialPos`. Because of the inline the codegen should be well optimised I think. This makes trait bounds better specifically (i.e. if I want a function taking `P: Into<CubePos>` then I can pass a `TilePos` without calling `AxialPos::from`).

I didn't add the borrow version (`From<&TilePos>`) as I saw a lot of the other structs had because I'm not really sure what it is for. If you want me to add it then let me know