### PR TITLE
Fix doc lints for Rust 1.73

### DIFF
--- a/src/helpers/filling.rs
+++ b/src/helpers/filling.rs
@@ -35,8 +35,8 @@ pub fn fill_tilemap(
 
 /// Fills a rectangular region with the given tile.
 ///
-/// The rectangular region is defined by an `origin` in [`TilePos`](crate::tiles::TilePos), and a
-/// `size` in tiles ([`TilemapSize`](crate::map::TilemapSize)).  
+/// The rectangular region is defined by an `origin` in [`TilePos`], and a
+/// `size` in tiles ([`TilemapSize`]).
 pub fn fill_tilemap_rect(
     texture_index: TileTextureIndex,
     origin: TilePos,
@@ -69,8 +69,8 @@ pub fn fill_tilemap_rect(
 
 /// Fills a rectangular region with colored versions of the given tile.
 ///
-/// The rectangular region is defined by an `origin` in [`TilePos`](crate::tiles::TilePos), and a
-/// `size` in tiles ([`TilemapSize`](crate::map::TilemapSize)).   
+/// The rectangular region is defined by an `origin` in [`TilePos`], and a
+/// `size` in tiles ([`TilemapSize`]).
 pub fn fill_tilemap_rect_color(
     texture_index: TileTextureIndex,
     origin: TilePos,
@@ -143,8 +143,7 @@ pub fn generate_hexagon(origin: AxialPos, radius: u32) -> Vec<AxialPos> {
 
 /// Fills a hexagonal region with the given `tile_texture`.
 ///
-/// The rectangular region is defined by an `origin` in [`TilePos`](crate::tiles::TilePos), and a
-/// `radius`.
+/// The rectangular region is defined by an `origin` in [`TilePos`], and a `radius`.
 ///
 /// Tiles that do not fit in the tilemap will not be created.
 pub fn fill_tilemap_hexagon(

--- a/src/helpers/hex_grid/axial.rs
+++ b/src/helpers/hex_grid/axial.rs
@@ -177,7 +177,7 @@ impl From<ColEvenPos> for AxialPos {
     }
 }
 
-/// The matrix for mapping from [`AxialPos`](AxialPos), to world position when hexes are arranged
+/// The matrix for mapping from [`AxialPos`], to world position when hexes are arranged
 /// in row format ("pointy top" per Red Blob Games). See
 /// [Size and Spacing](https://www.redblobgames.com/grids/hexagons/#size-and-spacing)
 /// at Red Blob Games for an interactive visual explanation, but note that:
@@ -185,13 +185,13 @@ impl From<ColEvenPos> for AxialPos {
 ///     2) our vectors have magnitude 1 (in order to allow for easy scaling based on grid-size)
 pub const ROW_BASIS: Mat2 = Mat2::from_cols(Vec2::new(1.0, 0.0), Vec2::new(0.5, HALF_SQRT_3));
 
-/// The inverse of [`ROW_BASIS`](ROW_BASIS).
+/// The inverse of [`ROW_BASIS`].
 pub const INV_ROW_BASIS: Mat2 = Mat2::from_cols(
     Vec2::new(1.0, 0.0),
     Vec2::new(-1.0 * INV_SQRT_3, DOUBLE_INV_SQRT_3),
 );
 
-/// The matrix for mapping from [`AxialPos`](AxialPos), to world position when hexes are arranged
+/// The matrix for mapping from [`AxialPos`], to world position when hexes are arranged
 /// in column format ("flat top" per Red Blob Games). See
 /// [Size and Spacing](https://www.redblobgames.com/grids/hexagons/#size-and-spacing)
 /// at Red Blob Games for an interactive visual explanation, but note that:
@@ -199,7 +199,7 @@ pub const INV_ROW_BASIS: Mat2 = Mat2::from_cols(
 ///     2) our vectors have magnitude 1 (in order to allow for easy scaling based on grid-size)
 pub const COL_BASIS: Mat2 = Mat2::from_cols(Vec2::new(HALF_SQRT_3, 0.5), Vec2::new(0.0, 1.0));
 
-/// The inverse of [`COL_BASIS`](COL_BASIS).
+/// The inverse of [`COL_BASIS`].
 pub const INV_COL_BASIS: Mat2 = Mat2::from_cols(
     Vec2::new(DOUBLE_INV_SQRT_3, -1.0 * INV_SQRT_3),
     Vec2::new(0.0, 1.0),

--- a/src/helpers/projection.rs
+++ b/src/helpers/projection.rs
@@ -10,7 +10,7 @@ use bevy::math::Vec2;
 impl TilePos {
     /// Get the center of this tile in world space.
     ///
-    /// The center is well defined for all [`TilemapType`](crate::map::TilemapType)s.
+    /// The center is well defined for all [`TilemapType`]s.
     pub fn center_in_world(&self, grid_size: &TilemapGridSize, map_type: &TilemapType) -> Vec2 {
         match map_type {
             TilemapType::Square { .. } => {

--- a/src/helpers/square_grid/diamond.rs
+++ b/src/helpers/square_grid/diamond.rs
@@ -13,7 +13,7 @@ use std::ops::{Add, Mul, Sub};
 ///
 /// It is vector-like. In other words: it makes sense to add and subtract
 /// two `DiamondPos`, and it makes sense to multiply a `DiamondPos` by
-/// an [`i32`](i32) scalar.
+/// an [`i32`] scalar.
 ///
 /// A `DiamondPos` can be mapped to world space, and a world space position can be mapped to
 /// the tile with `DiamondPos` containing said world space position.

--- a/src/helpers/square_grid/mod.rs
+++ b/src/helpers/square_grid/mod.rs
@@ -14,7 +14,7 @@ use std::ops::{Add, Mul, Sub};
 ///
 /// It is vector-like. In other words: it makes sense to add and subtract
 /// two `SquarePos`, and it makes sense to multiply a `SquarePos` by
-/// an [`i32`](i32) scalar.
+/// an [`i32`] scalar.
 ///
 /// A `SquarePos` can be mapped to world space, and a world space position can be mapped to
 /// the tile with `SquarePos` containing said world space position.


### PR DESCRIPTION
Rust 1.73 added `redundant_explicit_links`.