### PR TITLE
Adds MaterialTilemapKey to prelude

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,8 @@ pub mod prelude {
     #[cfg(feature = "render")]
     pub use crate::render::material::MaterialTilemap;
     #[cfg(feature = "render")]
+    pub use crate::render::material::MaterialTilemapKey;
+    #[cfg(feature = "render")]
     pub use crate::render::material::MaterialTilemapPlugin;
     #[cfg(feature = "render")]
     pub use crate::render::material::StandardTilemapMaterial;


### PR DESCRIPTION
This PR fixes https://github.com/StarArawn/bevy_ecs_tilemap/issues/477.

For context, if one wishes to implement the trait `MaterialTilemap`, they are not able to override the function:
```rust
fn specialize(descriptor: &mut RenderPipelineDescriptor, key: MaterialTilemapKey<Self>) {}
```
as it is not included in `bevy_ecs_tilemap::prelude::*`.