### PR TITLE
Fix tile color srgbness

### DIFF
--- a/src/render/chunk.rs
+++ b/src/render/chunk.rs
@@ -167,7 +167,7 @@ pub struct PackedTileData {
     pub visible: bool,
     pub position: Vec4,
     pub texture: Vec4,
-    pub color: Vec4,
+    pub color: [f32; 4],
 }
 
 #[derive(Clone, Debug)]
@@ -374,8 +374,7 @@ impl RenderChunk2d {
                     .into_iter(),
                 );
 
-                let color: [f32; 4] = tile.color.into();
-                colors.extend([color, color, color, color].into_iter());
+                colors.extend(std::iter::repeat(tile.color).take(4));
 
                 // flipping and rotation packed in bits
                 // bit 0 : flip_x

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -278,7 +278,7 @@ pub fn extract(
             visible: visible.0,
             position,
             texture,
-            color: color.0.into(),
+            color: color.0.as_linear_rgba_f32(),
         };
 
         let data = tilemap_query.get(tilemap_id.0).unwrap();


### PR DESCRIPTION
Fixes #479

Not as familiar as I would like to with the rendering code. Is it okay to change the type of the color field in `PackedTileData`? I could leave it the same, but the rest of the code would likely be uglier.