### PR TITLE
Add "new" function to structs with only numeric fields

### DIFF
--- a/src/helpers/hex_grid/axial.rs
+++ b/src/helpers/hex_grid/axial.rs
@@ -212,6 +212,10 @@ pub const UNIT_R: AxialPos = AxialPos { q: 0, r: -1 };
 pub const UNIT_S: AxialPos = AxialPos { q: 1, r: -1 };
 
 impl AxialPos {
+    pub fn new(q: i32, r: i32) -> Self {
+        Self { q, r }
+    }
+
     /// The magnitude of an axial position is its distance away from `(0, 0)` in the hex grid.
     ///
     /// See the Red Blob Games article for a [helpful interactive diagram](https://www.redblobgames.com/grids/hexagons/#distances-cube).
@@ -473,6 +477,10 @@ pub struct FractionalAxialPos {
 }
 
 impl FractionalAxialPos {
+    pub fn new(q: f32, r: f32) -> Self {
+        Self { q, r }
+    }
+
     #[inline]
     fn round(&self) -> AxialPos {
         let frac_cube_pos = FractionalCubePos::from(*self);

--- a/src/helpers/hex_grid/cube.rs
+++ b/src/helpers/hex_grid/cube.rs
@@ -92,6 +92,10 @@ impl Mul<CubePos> for u32 {
 }
 
 impl CubePos {
+    pub fn new(q: i32, r: i32, s: i32) -> Self {
+        Self { q, r, s }
+    }
+
     /// The magnitude of a cube position is its distance away from `[0, 0, 0]` in the cube grid.
     ///
     /// See the Red Blob Games article for a [helpful interactive diagram](https://www.redblobgames.com/grids/hexagons/#distances-cube).
@@ -123,6 +127,10 @@ impl From<FractionalAxialPos> for FractionalCubePos {
 }
 
 impl FractionalCubePos {
+    pub fn new(q: f32, r: f32, s: f32) -> Self {
+        Self { q, r, s }
+    }
+
     /// Returns `self` rounded to a [`CubePos`] that contains `self`. This is particularly useful
     /// for determining the hex tile that this fractional position is in.
     #[inline]

--- a/src/helpers/hex_grid/offset.rs
+++ b/src/helpers/hex_grid/offset.rs
@@ -13,6 +13,10 @@ pub struct RowOddPos {
 }
 
 impl RowOddPos {
+    pub fn new(q: i32, r: i32) -> Self {
+        Self { q, r }
+    }
+
     /// Returns the position of this tile's center, in world space.
     #[inline]
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
@@ -99,6 +103,10 @@ pub struct RowEvenPos {
 }
 
 impl RowEvenPos {
+    pub fn new(q: i32, r: i32) -> Self {
+        Self { q, r }
+    }
+
     /// Returns the position of this tile's center, in world space.
     #[inline]
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
@@ -185,6 +193,10 @@ pub struct ColOddPos {
 }
 
 impl ColOddPos {
+    pub fn new(q: i32, r: i32) -> Self {
+        Self { q, r }
+    }
+
     /// Returns the position of this tile's center, in world space.
     #[inline]
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {
@@ -271,6 +283,10 @@ pub struct ColEvenPos {
 }
 
 impl ColEvenPos {
+    pub fn new(q: i32, r: i32) -> Self {
+        Self { q, r }
+    }
+
     /// Returns the position of this tile's center, in world space.
     #[inline]
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {

--- a/src/helpers/square_grid/diamond.rs
+++ b/src/helpers/square_grid/diamond.rs
@@ -122,6 +122,10 @@ impl From<&SquarePos> for DiamondPos {
 }
 
 impl DiamondPos {
+    pub fn new(x: i32, y: i32) -> Self {
+        Self { x, y }
+    }
+
     /// Project a vector representing a fractional tile position (i.e. the components can be `f32`)
     /// into world space.
     ///

--- a/src/helpers/square_grid/mod.rs
+++ b/src/helpers/square_grid/mod.rs
@@ -100,6 +100,10 @@ impl From<StaggeredPos> for SquarePos {
 }
 
 impl SquarePos {
+    pub fn new(x: i32, y: i32) -> Self {
+        Self { x, y }
+    }
+
     /// Project a vector representing a fractional tile position (i.e. the components can be `f32`)
     /// into world space.
     ///

--- a/src/helpers/square_grid/staggered.rs
+++ b/src/helpers/square_grid/staggered.rs
@@ -89,6 +89,10 @@ impl Mul<StaggeredPos> for i32 {
 }
 
 impl StaggeredPos {
+    pub fn new(x: i32, y: i32) -> Self {
+        Self { x, y }
+    }
+
     /// Returns the position of this tile's center, in world space.
     #[inline]
     pub fn center_in_world(&self, grid_size: &TilemapGridSize) -> Vec2 {

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -59,6 +59,10 @@ pub struct TilemapSize {
 }
 
 impl TilemapSize {
+    pub fn new(x: u32, y: u32) -> Self {
+        Self { x, y }
+    }
+
     pub fn count(&self) -> usize {
         (self.x * self.y) as usize
     }
@@ -201,6 +205,12 @@ pub struct TilemapTileSize {
     pub y: f32,
 }
 
+impl TilemapTileSize {
+    pub fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+}
+
 impl From<TilemapTileSize> for TilemapGridSize {
     fn from(tile_size: TilemapTileSize) -> Self {
         TilemapGridSize {
@@ -238,6 +248,12 @@ impl From<Vec2> for TilemapTileSize {
 pub struct TilemapGridSize {
     pub x: f32,
     pub y: f32,
+}
+
+impl TilemapGridSize {
+    pub fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
 }
 
 impl From<TilemapGridSize> for Vec2 {
@@ -280,6 +296,10 @@ impl From<TilemapSpacing> for Vec2 {
 }
 
 impl TilemapSpacing {
+    pub fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+
     pub fn zero() -> Self {
         Self { x: 0.0, y: 0.0 }
     }
@@ -291,6 +311,12 @@ impl TilemapSpacing {
 pub struct TilemapTextureSize {
     pub x: f32,
     pub y: f32,
+}
+
+impl TilemapTextureSize {
+    pub fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
 }
 
 impl From<TilemapTextureSize> for Vec2 {


### PR DESCRIPTION
### Summary
This PR adds a "new" function to structs with only numeric fields, allowing the user to instantiate them in a more concise way.

### Reasoning
- "new" functions are more concise and convenient then struct literal syntax when it comes to structs with only numeric fields
- _TilePos_, a struct included in the library, has a "new" function, while other structs do not. Giving structs that are similar to _TilePos_ a "new" function would make the library more consistent

### Example 
The _TilemapSize_ struct has only two fields: x and y, both of which are u32s. If the user wanted to create an instance of this struct with x and y both being 1, instead of instantiating the struct with the struct literal syntax, this PR would allow them to call _TilemapSize::new(1, 1)_.

