### PR TITLE
Add const to some functions.

### DIFF
--- a/src/helpers/hex_grid/axial.rs
+++ b/src/helpers/hex_grid/axial.rs
@@ -219,7 +219,7 @@ pub const UNIT_R: AxialPos = AxialPos { q: 0, r: -1 };
 pub const UNIT_S: AxialPos = AxialPos { q: 1, r: -1 };
 
 impl AxialPos {
-    pub fn new(q: i32, r: i32) -> Self {
+    pub const fn new(q: i32, r: i32) -> Self {
         Self { q, r }
     }
 
@@ -485,7 +485,7 @@ pub struct FractionalAxialPos {
 }
 
 impl FractionalAxialPos {
-    pub fn new(q: f32, r: f32) -> Self {
+    pub const fn new(q: f32, r: f32) -> Self {
         Self { q, r }
     }
 

--- a/src/helpers/hex_grid/cube.rs
+++ b/src/helpers/hex_grid/cube.rs
@@ -103,7 +103,7 @@ impl Mul<CubePos> for u32 {
 }
 
 impl CubePos {
-    pub fn new(q: i32, r: i32, s: i32) -> Self {
+    pub const fn new(q: i32, r: i32, s: i32) -> Self {
         Self { q, r, s }
     }
 
@@ -139,7 +139,7 @@ impl From<FractionalAxialPos> for FractionalCubePos {
 }
 
 impl FractionalCubePos {
-    pub fn new(q: f32, r: f32, s: f32) -> Self {
+    pub const fn new(q: f32, r: f32, s: f32) -> Self {
         Self { q, r, s }
     }
 

--- a/src/helpers/hex_grid/offset.rs
+++ b/src/helpers/hex_grid/offset.rs
@@ -14,7 +14,7 @@ pub struct RowOddPos {
 }
 
 impl RowOddPos {
-    pub fn new(q: i32, r: i32) -> Self {
+    pub const fn new(q: i32, r: i32) -> Self {
         Self { q, r }
     }
 
@@ -105,7 +105,7 @@ pub struct RowEvenPos {
 }
 
 impl RowEvenPos {
-    pub fn new(q: i32, r: i32) -> Self {
+    pub const fn new(q: i32, r: i32) -> Self {
         Self { q, r }
     }
 
@@ -196,7 +196,7 @@ pub struct ColOddPos {
 }
 
 impl ColOddPos {
-    pub fn new(q: i32, r: i32) -> Self {
+    pub const fn new(q: i32, r: i32) -> Self {
         Self { q, r }
     }
 
@@ -287,7 +287,7 @@ pub struct ColEvenPos {
 }
 
 impl ColEvenPos {
-    pub fn new(q: i32, r: i32) -> Self {
+    pub const fn new(q: i32, r: i32) -> Self {
         Self { q, r }
     }
 

--- a/src/helpers/square_grid/diamond.rs
+++ b/src/helpers/square_grid/diamond.rs
@@ -123,7 +123,7 @@ impl From<&SquarePos> for DiamondPos {
 }
 
 impl DiamondPos {
-    pub fn new(x: i32, y: i32) -> Self {
+    pub const fn new(x: i32, y: i32) -> Self {
         Self { x, y }
     }
 

--- a/src/helpers/square_grid/mod.rs
+++ b/src/helpers/square_grid/mod.rs
@@ -101,7 +101,7 @@ impl From<StaggeredPos> for SquarePos {
 }
 
 impl SquarePos {
-    pub fn new(x: i32, y: i32) -> Self {
+    pub const fn new(x: i32, y: i32) -> Self {
         Self { x, y }
     }
 

--- a/src/helpers/square_grid/staggered.rs
+++ b/src/helpers/square_grid/staggered.rs
@@ -90,7 +90,7 @@ impl Mul<StaggeredPos> for i32 {
 }
 
 impl StaggeredPos {
-    pub fn new(x: i32, y: i32) -> Self {
+    pub const fn new(x: i32, y: i32) -> Self {
         Self { x, y }
     }
 

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -67,11 +67,11 @@ pub struct TilemapSize {
 }
 
 impl TilemapSize {
-    pub fn new(x: u32, y: u32) -> Self {
+    pub const fn new(x: u32, y: u32) -> Self {
         Self { x, y }
     }
 
-    pub fn count(&self) -> usize {
+    pub const fn count(&self) -> usize {
         (self.x * self.y) as usize
     }
 }
@@ -214,7 +214,7 @@ pub struct TilemapTileSize {
 }
 
 impl TilemapTileSize {
-    pub fn new(x: f32, y: f32) -> Self {
+    pub const fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }
 }
@@ -259,7 +259,7 @@ pub struct TilemapGridSize {
 }
 
 impl TilemapGridSize {
-    pub fn new(x: f32, y: f32) -> Self {
+    pub const fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }
 }
@@ -304,11 +304,11 @@ impl From<TilemapSpacing> for Vec2 {
 }
 
 impl TilemapSpacing {
-    pub fn new(x: f32, y: f32) -> Self {
+    pub const fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }
 
-    pub fn zero() -> Self {
+    pub const fn zero() -> Self {
         Self { x: 0.0, y: 0.0 }
     }
 }
@@ -322,7 +322,7 @@ pub struct TilemapTextureSize {
 }
 
 impl TilemapTextureSize {
-    pub fn new(x: f32, y: f32) -> Self {
+    pub const fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -66,7 +66,7 @@ pub struct DefaultSampler(ImageSamplerDescriptor);
 pub(crate) struct RenderChunkSize(UVec2);
 
 impl RenderChunkSize {
-    pub fn new(chunk_size: UVec2) -> RenderChunkSize {
+    pub const fn new(chunk_size: UVec2) -> RenderChunkSize {
         RenderChunkSize(chunk_size)
     }
 

--- a/src/tiles/mod.rs
+++ b/src/tiles/mod.rs
@@ -19,7 +19,7 @@ pub struct TilePos {
 }
 
 impl TilePos {
-    pub fn new(x: u32, y: u32) -> Self {
+    pub const fn new(x: u32, y: u32) -> Self {
         Self { x, y }
     }
 


### PR DESCRIPTION
It just make some `::new()` function to be const.

allowing it to be call on const definitions like this:

```rust
// Old
const SIZE: TilemapSize = TilemapSize{ x: 256, y: 256 };

// New
const SIZE: TilemapSize = TilemapSize::new(256, 256);
```  
And some compile time optimizations.