### PR TITLE
Filter RemovedComponents for entities that no longer exist

### DIFF
--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -377,15 +377,15 @@ pub fn extract(
 
 pub fn extract_removal(
     mut commands: Commands,
-    removed_tiles_query: Extract<Query<&RemovedTileEntity>>,
-    removed_maps_query: Extract<Query<&RemovedMapEntity>>,
+    removed_tiles_query: Extract<Query<(Entity, &RemovedTileEntity)>>,
+    removed_maps_query: Extract<Query<(Entity, &RemovedMapEntity)>>,
 ) {
     let mut removed_tiles: Vec<(Entity, ExtractedRemovedTileBundle)> = Vec::new();
-    for entity in removed_tiles_query.iter() {
+    for (entity, removed) in removed_tiles_query.iter() {
         removed_tiles.push((
-            entity.0,
+            entity,
             ExtractedRemovedTileBundle {
-                tile: ExtractedRemovedTile { entity: entity.0 },
+                tile: ExtractedRemovedTile { entity: removed.0 },
             },
         ));
     }
@@ -393,11 +393,11 @@ pub fn extract_removal(
     commands.insert_or_spawn_batch(removed_tiles);
 
     let mut removed_maps: Vec<(Entity, ExtractedRemovedMapBundle)> = Vec::new();
-    for entity in removed_maps_query.iter() {
+    for (entity, removed) in removed_maps_query.iter() {
         removed_maps.push((
-            entity.0,
+            entity,
             ExtractedRemovedMapBundle {
-                map: ExtractedRemovedMap { entity: entity.0 },
+                map: ExtractedRemovedMap { entity: removed.0 },
             },
         ));
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -309,20 +309,18 @@ pub struct RemovedMapEntity(pub Entity);
 
 fn removal_helper(
     mut commands: Commands,
-    entities: &Entities,
     mut removed_query: RemovedComponents<TilePos>,
 ) {
-    for entity in removed_query.read().filter(|entity| entities.contains(*entity)) {
+    for entity in removed_query.read() {
         commands.spawn(RemovedTileEntity(entity));
     }
 }
 
 fn removal_helper_tilemap(
     mut commands: Commands,
-    entities: &Entities,
     mut removed_query: RemovedComponents<TileStorage>,
 ) {
-    for entity in removed_query.read().filter(|entity| entities.contains(*entity)) {
+    for entity in removed_query.read() {
         commands.spawn(RemovedMapEntity(entity));
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -116,7 +116,7 @@ impl Plugin for TilemapRenderingPlugin {
         app.add_systems(Update, set_texture_to_copy_src);
 
         app.add_systems(First, clear_removed);
-        app.add_systems(PostUpdate, (removal_helper_tilemap, removal_helper));
+        app.add_systems(PostUpdate, removal_helper);
 
         app.add_plugins(MaterialTilemapPlugin::<StandardTilemapMaterial>::default());
 
@@ -306,17 +306,33 @@ pub struct RemovedTileEntity(pub Entity);
 #[derive(Component)]
 pub struct RemovedMapEntity(pub Entity);
 
-fn removal_helper(mut commands: Commands, mut removed_query: RemovedComponents<TilePos>) {
-    for entity in removed_query.read() {
+// fn removal_helper(mut commands: Commands, mut removed_query: RemovedComponents<TilePos>) {
+//     for entity in removed_query.read() {
+//         commands.spawn(RemovedTileEntity(entity));
+//     }
+// }
+//
+// fn removal_helper_tilemap(
+//     mut commands: Commands,
+//     mut removed_query: RemovedComponents<TileStorage>,
+// ) {
+//     for entity in removed_query.read() {
+//         commands.spawn(RemovedMapEntity(entity));
+//     }
+// }
+
+fn removal_helper(mut commands: Commands, mut set: ParamSet<(&World, RemovedComponents<TilePos>, RemovedComponents<TileStorage>)>) {
+    let tiles: Vec<Entity> = set.p1().read().collect();
+    let maps: Vec<Entity> = set.p2().read().collect();
+
+    let world = set.p0();
+    let entities = world.entities();
+
+    for entity in tiles.into_iter().filter(|entity| entities.contains(*entity)) {
         commands.spawn(RemovedTileEntity(entity));
     }
-}
 
-fn removal_helper_tilemap(
-    mut commands: Commands,
-    mut removed_query: RemovedComponents<TileStorage>,
-) {
-    for entity in removed_query.read() {
+    for entity in maps.into_iter().filter(|entity| entities.contains(*entity)) {
         commands.spawn(RemovedMapEntity(entity));
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -12,7 +12,6 @@ use bevy::{
         Render, RenderApp, RenderSet,
     },
 };
-use bevy::ecs::entity::Entities;
 
 #[cfg(not(feature = "atlas"))]
 use bevy::render::renderer::RenderDevice;
@@ -307,10 +306,7 @@ pub struct RemovedTileEntity(pub Entity);
 #[derive(Component)]
 pub struct RemovedMapEntity(pub Entity);
 
-fn removal_helper(
-    mut commands: Commands,
-    mut removed_query: RemovedComponents<TilePos>,
-) {
+fn removal_helper(mut commands: Commands, mut removed_query: RemovedComponents<TilePos>) {
     for entity in removed_query.read() {
         commands.spawn(RemovedTileEntity(entity));
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -306,21 +306,6 @@ pub struct RemovedTileEntity(pub Entity);
 #[derive(Component)]
 pub struct RemovedMapEntity(pub Entity);
 
-// fn removal_helper(mut commands: Commands, mut removed_query: RemovedComponents<TilePos>) {
-//     for entity in removed_query.read() {
-//         commands.spawn(RemovedTileEntity(entity));
-//     }
-// }
-//
-// fn removal_helper_tilemap(
-//     mut commands: Commands,
-//     mut removed_query: RemovedComponents<TileStorage>,
-// ) {
-//     for entity in removed_query.read() {
-//         commands.spawn(RemovedMapEntity(entity));
-//     }
-// }
-
 fn removal_helper(mut commands: Commands, mut set: ParamSet<(&World, RemovedComponents<TilePos>, RemovedComponents<TileStorage>)>) {
     let tiles: Vec<Entity> = set.p1().read().collect();
     let maps: Vec<Entity> = set.p2().read().collect();

--- a/src/render/texture_array_cache.rs
+++ b/src/render/texture_array_cache.rs
@@ -86,7 +86,7 @@ impl TextureArrayCache {
                         "Expected image to have finished loading if \
                         it is being extracted as a texture!",
                     );
-                    let this_tile_size: TilemapTileSize = image.size_f32().try_into().unwrap();
+                    let this_tile_size: TilemapTileSize = image.size_f32().into();
                     if this_tile_size != tile_size {
                         panic!(
                             "Expected all provided image assets to have size {tile_size:?}, \


### PR DESCRIPTION
Fixes #509 

Here is an MVCE demonstrating a crash:
```rust
use bevy::prelude::*;
use bevy_ecs_tilemap::prelude::*;

fn main() {
    App::new()
        .add_plugins((DefaultPlugins, TilemapPlugin))
        .add_state::<ExampleState>()
        .add_systems(Startup, setup)
        .add_systems(Update, transition.run_if(in_state(ExampleState::State1)))
        .add_systems(OnExit(ExampleState::State1), despawn)
        .add_systems(OnEnter(ExampleState::State2), spawn)
        .run();
}

#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, States)]
enum ExampleState {
    #[default]
    State1,
    State2,
}

fn setup(mut commands: Commands) {
    commands.spawn(Camera2dBundle::default());
    commands.spawn(TilemapBundle::default());
}

fn transition(mut next_state: ResMut<NextState<ExampleState>>) {
    println!("transitioning");
    next_state.set(ExampleState::State2);
}

fn despawn(mut commands: Commands, query: Query<Entity, With<TileStorage>>) {
    for entity in &query {
        println!("despawning {entity:?}");
        commands.entity(entity).despawn();
    }
}

fn spawn(mut commands: Commands) {
    let entity = commands.spawn_empty().id();
    println!("spawning {entity:?}");
    commands.entity(entity).insert(SpriteBundle::default());
}
```

> transitioning
despawning 2v0
spawning 2v1
2024-02-02T18:54:12.858004Z ERROR bevy_ecs::system::commands: Failed to 'insert or spawn' bundle of type bevy_sprite::render::SpriteBatch into the following invalid entities: [2v1]
thread '<unnamed>' panicked at C:\Users\s33n\.cargo\registry\src\index.crates.io-6f17d22bba15001f\bevy_render-0.12.1\src\render_phase\draw.rs:275:67:
called `Result::unwrap()` on an `Err` value: NoSuchEntity(2v1)


I believe the root problem is that we are erroneously inserting an Entity `2v0` into the render world via `ExtractedRemovedMapBundle` when that entity in our current world is now `2v1`. This appears to interfere with systems that interact with that entity in the render world.