### PR TITLE
Moved render settings onto entity.

### DIFF
--- a/examples/3d_iso.rs
+++ b/examples/3d_iso.rs
@@ -10,18 +10,18 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     commands.spawn(helpers::tiled::TiledMapBundle {
         tiled_map: map_handle,
+        render_settings: TilemapRenderSettings {
+            // Map size is 12x12 so we'll have render chunks that are:
+            // 12 tiles wide and 1 tile tall.
+            render_chunk_size: UVec2::new(3, 1),
+            y_sort: true,
+        },
         ..Default::default()
     });
 }
 
 fn main() {
     App::new()
-        .insert_resource(TilemapRenderSettings {
-            // Map size is 12x12 so we'll have render chunks that are:
-            // 12 tiles wide and 1 tile tall.
-            render_chunk_size: UVec2::new(3, 1),
-            y_sort: true,
-        })
         .add_plugins(
             DefaultPlugins
                 .set(WindowPlugin {

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -43,10 +43,6 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
 }
 
-fn display_t_entities(query: Query<Entity, With<Transform>>) {
-    dbg!(query.iter().count());
-}
-
 fn main() {
     App::new()
         .add_plugins(
@@ -64,6 +60,6 @@ fn main() {
         .add_plugins(FrameTimeDiagnosticsPlugin)
         .add_plugins(TilemapPlugin)
         .add_systems(Startup, startup)
-        .add_systems(Update, (helpers::camera::movement, display_t_entities))
+        .add_systems(Update, helpers::camera::movement)
         .run();
 }

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -35,6 +35,10 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         texture: TilemapTexture::Single(texture_handle),
         tile_size,
         transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+        render_settings: TilemapRenderSettings {
+            render_chunk_size: UVec2::new(256, 256),
+            ..Default::default()
+        },
         ..Default::default()
     });
 }
@@ -56,10 +60,6 @@ fn main() {
                 })
                 .set(ImagePlugin::default_nearest()),
         )
-        .insert_resource(TilemapRenderSettings {
-            render_chunk_size: UVec2::new(256, 256),
-            ..Default::default()
-        })
         .add_plugins(LogDiagnosticsPlugin::default())
         .add_plugins(FrameTimeDiagnosticsPlugin)
         .add_plugins(TilemapPlugin)

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -39,6 +39,10 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
 }
 
+fn display_t_entities(query: Query<Entity, With<Transform>>) {
+    dbg!(query.iter().count());
+}
+
 fn main() {
     App::new()
         .add_plugins(
@@ -60,6 +64,6 @@ fn main() {
         .add_plugins(FrameTimeDiagnosticsPlugin)
         .add_plugins(TilemapPlugin)
         .add_systems(Startup, startup)
-        .add_systems(Update, helpers::camera::movement)
+        .add_systems(Update, (helpers::camera::movement, display_t_entities))
         .run();
 }

--- a/examples/chunking.rs
+++ b/examples/chunking.rs
@@ -45,6 +45,10 @@ fn spawn_chunk(commands: &mut Commands, asset_server: &AssetServer, chunk_pos: I
         texture: TilemapTexture::Single(texture_handle),
         tile_size: TILE_SIZE,
         transform,
+        render_settings: TilemapRenderSettings {
+            render_chunk_size: RENDER_CHUNK_SIZE,
+            ..Default::default()
+        },
         ..Default::default()
     });
 }
@@ -117,11 +121,7 @@ fn main() {
                 })
                 .set(ImagePlugin::default_nearest()),
         )
-        // `TilemapRenderSettings` be added before the `TilemapPlugin`.
-        .insert_resource(TilemapRenderSettings {
-            render_chunk_size: RENDER_CHUNK_SIZE,
-            ..Default::default()
-        })
+        // `TilemapRenderS
         .add_plugins(TilemapPlugin)
         .insert_resource(ChunkManager::default())
         .add_systems(Startup, startup)

--- a/examples/chunking.rs
+++ b/examples/chunking.rs
@@ -121,7 +121,6 @@ fn main() {
                 })
                 .set(ImagePlugin::default_nearest()),
         )
-        // `TilemapRenderS
         .add_plugins(TilemapPlugin)
         .insert_resource(ChunkManager::default())
         .add_systems(Startup, startup)

--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -65,6 +65,7 @@ pub struct TiledMapBundle {
     pub storage: TiledLayersStorage,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
+    pub render_settings: TilemapRenderSettings,
 }
 
 struct BytesResourceReader {
@@ -200,7 +201,11 @@ pub fn process_loaded_maps(
     mut map_events: EventReader<AssetEvent<TiledMap>>,
     maps: Res<Assets<TiledMap>>,
     tile_storage_query: Query<(Entity, &TileStorage)>,
-    mut map_query: Query<(&Handle<TiledMap>, &mut TiledLayersStorage)>,
+    mut map_query: Query<(
+        &Handle<TiledMap>,
+        &mut TiledLayersStorage,
+        &TilemapRenderSettings,
+    )>,
     new_maps: Query<&Handle<TiledMap>, Added<Handle<TiledMap>>>,
 ) {
     let mut changed_maps = Vec::<AssetId<TiledMap>>::default();
@@ -230,7 +235,7 @@ pub fn process_loaded_maps(
     }
 
     for changed_map in changed_maps.iter() {
-        for (map_handle, mut layer_storage) in map_query.iter_mut() {
+        for (map_handle, mut layer_storage, render_settings) in map_query.iter_mut() {
             // only deal with currently changed map
             if map_handle.id() != *changed_map {
                 continue;
@@ -382,6 +387,7 @@ pub fn process_loaded_maps(
                                 layer_index as f32,
                             ) * Transform::from_xyz(offset_x, -offset_y, 0.0),
                             map_type,
+                            render_settings: *render_settings,
                             ..Default::default()
                         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use map::{
     TilemapGridSize, TilemapSize, TilemapSpacing, TilemapTexture, TilemapTextureSize,
     TilemapTileSize, TilemapType,
 };
-use prelude::TilemapId;
+use prelude::{TilemapId, TilemapRenderSettings};
 #[cfg(feature = "render")]
 use render::material::{MaterialTilemap, StandardTilemapMaterial};
 use tiles::{
@@ -114,6 +114,7 @@ pub struct MaterialTilemapBundle<M: MaterialTilemap> {
     pub tile_size: TilemapTileSize,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
+    pub render_settings: TilemapRenderSettings,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted
@@ -138,6 +139,7 @@ pub struct StandardTilemapBundle {
     pub tile_size: TilemapTileSize,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
+    pub render_settings: TilemapRenderSettings,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -1,7 +1,7 @@
 use bevy::asset::Assets;
 use bevy::ecs::entity::{EntityMapper, MapEntities};
 use bevy::ecs::reflect::ReflectMapEntities;
-use bevy::prelude::{ReflectComponent, Res, ResMut, Resource};
+use bevy::prelude::{ReflectComponent, Res, ResMut};
 use bevy::render::render_resource::TextureUsages;
 use bevy::{
     math::{UVec2, Vec2},
@@ -10,20 +10,8 @@ use bevy::{
 
 /// Custom parameters for the render pipeline.
 ///
-/// It must be added as a resource before [`TilemapPlugin`](crate::TilemapPlugin). For example:
-/// ```ignore
-/// App::new()
-///     .insert_resource(WindowDescriptor {
-///         width: 1270.0,
-///         height: 720.0,
-///     })
-///     .insert_resource(TilemapRenderSettings {
-///         render_chunk_size: UVec2::new(32, 32),
-///     })
-///     .add_plugin(TilemapPlugin)
-///     .run();
-/// ```
-#[derive(Resource, Debug, Default, Copy, Clone)]
+/// It must be added as a component to the tilemap entity.
+#[derive(Component, Debug, Default, Copy, Clone)]
 pub struct TilemapRenderSettings {
     /// Dimensions of a "chunk" in tiles. Chunks are grouping of tiles combined and rendered as a
     /// single mesh by the render pipeline.

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -8,7 +8,8 @@ use bevy::{
     prelude::{Component, Entity, Handle, Image, Reflect},
 };
 
-use crate::render::CHUNK_SIZE_2D;
+/// The default chunk_size (in tiles) used per mesh.
+pub const CHUNK_SIZE_2D: UVec2 = UVec2::from_array([64, 64]);
 
 /// Custom parameters for the render pipeline.
 ///

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -8,10 +8,12 @@ use bevy::{
     prelude::{Component, Entity, Handle, Image, Reflect},
 };
 
+use crate::render::CHUNK_SIZE_2D;
+
 /// Custom parameters for the render pipeline.
 ///
 /// It must be added as a component to the tilemap entity.
-#[derive(Component, Debug, Default, Copy, Clone)]
+#[derive(Component, Debug, Copy, Clone)]
 pub struct TilemapRenderSettings {
     /// Dimensions of a "chunk" in tiles. Chunks are grouping of tiles combined and rendered as a
     /// single mesh by the render pipeline.
@@ -27,6 +29,15 @@ pub struct TilemapRenderSettings {
     ///
     /// `render_chunk_size`'s `z` value should be `1` when using this for 3d isometric tilemaps.
     pub y_sort: bool,
+}
+
+impl Default for TilemapRenderSettings {
+    fn default() -> Self {
+        Self {
+            render_chunk_size: CHUNK_SIZE_2D,
+            y_sort: false,
+        }
+    }
 }
 
 /// A component which stores a reference to the tilemap entity.

--- a/src/render/chunk.rs
+++ b/src/render/chunk.rs
@@ -22,6 +22,8 @@ use crate::{
     FrustumCulling, TilemapGridSize, TilemapTileSize,
 };
 
+use super::RenderChunkSize;
+
 #[derive(Resource, Default, Clone, Debug)]
 pub struct RenderChunk2dStorage {
     chunks: HashMap<u32, HashMap<UVec3, RenderChunk2d>>,
@@ -51,6 +53,8 @@ impl RenderChunk2dStorage {
         transform: GlobalTransform,
         visibility: &InheritedVisibility,
         frustum_culling: &FrustumCulling,
+        render_size: RenderChunkSize,
+        y_sort: bool,
     ) -> &mut RenderChunk2d {
         let pos = position.xyz();
 
@@ -86,6 +90,8 @@ impl RenderChunk2dStorage {
                 transform,
                 visibility.get(),
                 **frustum_culling,
+                render_size,
+                y_sort,
             );
             self.entity_to_chunk.insert(chunk_entity, pos);
             chunk_storage.insert(pos, chunk);
@@ -208,6 +214,8 @@ pub struct RenderChunk2d {
     pub dirty_mesh: bool,
     pub visible: bool,
     pub frustum_culling: bool,
+    pub render_size: RenderChunkSize,
+    pub y_sort: bool,
 }
 
 impl RenderChunk2d {
@@ -227,6 +235,8 @@ impl RenderChunk2d {
         global_transform: GlobalTransform,
         visible: bool,
         frustum_culling: bool,
+        render_size: RenderChunkSize,
+        y_sort: bool,
     ) -> Self {
         let position = chunk_index_to_world_space(index.xy(), size_in_tiles, &grid_size, &map_type);
         let local_transform = Transform::from_translation(position.extend(0.0));
@@ -258,6 +268,8 @@ impl RenderChunk2d {
             tiles: vec![None; (size_in_tiles.x * size_in_tiles.y) as usize],
             visible,
             frustum_culling,
+            render_size,
+            y_sort,
         }
     }
 

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -7,6 +7,7 @@ use bevy::render::render_resource::TextureFormat;
 use bevy::{math::Vec4, prelude::*, render::Extract, utils::HashMap};
 
 use crate::prelude::TilemapGridSize;
+use crate::prelude::TilemapRenderSettings;
 use crate::render::{DefaultSampler, SecondsSinceStartup};
 use crate::tiles::AnimatedTile;
 use crate::tiles::TilePosOld;
@@ -68,6 +69,7 @@ pub struct ExtractedTilemapBundle {
     map_size: TilemapSize,
     visibility: InheritedVisibility,
     frustum_culling: FrustumCulling,
+    render_settings: TilemapRenderSettings,
 }
 
 #[derive(Component)]
@@ -220,6 +222,7 @@ pub fn extract(
             &TilemapSize,
             &InheritedVisibility,
             &FrustumCulling,
+            &TilemapRenderSettings,
         )>,
     >,
     changed_tilemap_query: Extract<
@@ -236,6 +239,7 @@ pub fn extract(
                 Changed<TilemapSize>,
                 Changed<InheritedVisibility>,
                 Changed<FrustumCulling>,
+                Changed<TilemapRenderSettings>,
             )>,
         >,
     >,
@@ -300,6 +304,7 @@ pub fn extract(
                     map_size: *data.7,
                     visibility: *data.8,
                     frustum_culling: *data.9,
+                    render_settings: *data.10,
                 },
             ),
         );
@@ -335,6 +340,7 @@ pub fn extract(
                         map_size: *data.7,
                         visibility: *data.8,
                         frustum_culling: *data.9,
+                        render_settings: *data.10,
                     },
                 ),
             );
@@ -345,7 +351,7 @@ pub fn extract(
         extracted_tilemaps.drain().map(|kv| kv.1).collect();
 
     // Extracts tilemap textures.
-    for (entity, _, tile_size, tile_spacing, _, _, texture, _, _, _) in tilemap_query.iter() {
+    for (entity, _, tile_size, tile_spacing, _, _, texture, _, _, _, _) in tilemap_query.iter() {
         if texture.verify_ready(&images) {
             extracted_tilemap_textures.push((
                 entity,

--- a/src/render/material.rs
+++ b/src/render/material.rs
@@ -31,7 +31,6 @@ use super::{
     draw::DrawTilemapMaterial,
     pipeline::{TilemapPipeline, TilemapPipelineKey},
     queue::{ImageBindGroups, TilemapViewBindGroup},
-    RenderYSort,
 };
 
 #[cfg(not(feature = "atlas"))]
@@ -362,7 +361,6 @@ fn prepare_material_tilemap<M: MaterialTilemap>(
 
 #[allow(clippy::too_many_arguments)]
 pub fn queue_material_tilemap_meshes<M: MaterialTilemap>(
-    y_sort: Res<RenderYSort>,
     chunk_storage: Res<RenderChunk2dStorage>,
     transparent_2d_draw_functions: Res<DrawFunctions<Transparent2d>>,
     render_device: Res<RenderDevice>,
@@ -455,7 +453,7 @@ pub fn queue_material_tilemap_meshes<M: MaterialTilemap>(
                         bind_group_data: material.key.clone(),
                     },
                 );
-                let z = if **y_sort {
+                let z = if chunk.y_sort {
                     transform.translation.z
                         + (1.0
                             - (transform.translation.y

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -50,7 +50,7 @@ use self::extract::ExtractedTilemapTexture;
 pub(crate) use self::texture_array_cache::TextureArrayCache;
 
 /// The default chunk_size (in tiles) used per mesh.
-const CHUNK_SIZE_2D: UVec2 = UVec2::from_array([64, 64]);
+pub const CHUNK_SIZE_2D: UVec2 = UVec2::from_array([64, 64]);
 
 #[derive(Copy, Clone, Debug, Component)]
 pub(crate) struct ExtractedFilterMode(FilterMode);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -49,9 +49,6 @@ use self::extract::ExtractedTilemapTexture;
 #[cfg(not(feature = "atlas"))]
 pub(crate) use self::texture_array_cache::TextureArrayCache;
 
-/// The default chunk_size (in tiles) used per mesh.
-pub const CHUNK_SIZE_2D: UVec2 = UVec2::from_array([64, 64]);
-
 #[derive(Copy, Clone, Debug, Component)]
 pub(crate) struct ExtractedFilterMode(FilterMode);
 

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -4,6 +4,7 @@ use crate::map::{
     TilemapId, TilemapSize, TilemapSpacing, TilemapTexture, TilemapTextureSize, TilemapTileSize,
     TilemapType,
 };
+use crate::prelude::TilemapRenderSettings;
 use crate::render::extract::ExtractedFrustum;
 use crate::{
     prelude::TilemapGridSize, render::RenderChunkSize, render::SecondsSinceStartup, FrustumCulling,
@@ -42,7 +43,6 @@ pub(crate) fn prepare(
     mut chunk_storage: ResMut<RenderChunk2dStorage>,
     mut mesh_uniforms: ResMut<MeshUniformResource>,
     mut tilemap_uniforms: ResMut<TilemapUniformResource>,
-    chunk_size: Res<RenderChunkSize>,
     extracted_tiles: Query<&ExtractedTile>,
     extracted_tilemaps: Query<(
         Entity,
@@ -56,6 +56,7 @@ pub(crate) fn prepare(
         &TilemapSize,
         &InheritedVisibility,
         &FrustumCulling,
+        &TilemapRenderSettings,
     )>,
     extracted_tilemap_textures: Query<&ExtractedTilemapTexture>,
     extracted_frustum_query: Query<&ExtractedFrustum>,
@@ -69,7 +70,6 @@ pub(crate) fn prepare(
             chunk_storage.remove_tile_with_entity(tile.entity);
         }
 
-        let chunk_index = chunk_size.map_tile_to_chunk(&tile.position);
         let (
             _entity,
             transform,
@@ -82,7 +82,10 @@ pub(crate) fn prepare(
             map_size,
             visibility,
             frustum_culling,
+            tilemap_render_settings,
         ) = extracted_tilemaps.get(tile.tilemap_id.0).unwrap();
+        let chunk_size = RenderChunkSize(tilemap_render_settings.render_chunk_size);
+        let chunk_index = chunk_size.map_tile_to_chunk(&tile.position);
 
         let chunk_data = UVec4::new(
             chunk_index.x,
@@ -97,7 +100,7 @@ pub(crate) fn prepare(
             in_chunk_tile_index,
             tile.tilemap_id.0,
             &chunk_data,
-            **chunk_size,
+            *chunk_size,
             *mesh_type,
             *tile_size,
             (*texture_size).into(),
@@ -108,6 +111,8 @@ pub(crate) fn prepare(
             *transform,
             visibility,
             frustum_culling,
+            chunk_size,
+            tilemap_render_settings.y_sort,
         );
         chunk.set(
             &in_chunk_tile_index.into(),
@@ -135,6 +140,7 @@ pub(crate) fn prepare(
         map_size,
         visibility,
         frustum_culling,
+        _,
     ) in extracted_tilemaps.iter()
     {
         let chunks = chunk_storage.get_chunk_storage(&UVec4::new(0, 0, 0, entity.index()));

--- a/src/render/texture_array_cache.rs
+++ b/src/render/texture_array_cache.rs
@@ -86,7 +86,7 @@ impl TextureArrayCache {
                         "Expected image to have finished loading if \
                         it is being extracted as a texture!",
                     );
-                    let this_tile_size: TilemapTileSize = image.size_f32().try_into().unwrap();
+                    let this_tile_size: TilemapTileSize = image.size_f32().into();
                     if this_tile_size != tile_size {
                         panic!(
                             "Expected all provided image assets to have size {tile_size:?}, \


### PR DESCRIPTION
## Description
This allows a user to customize render settings per tilemap entity.

## Why is this useful?
It allows users to specify render chunk sizes per tilemap/layer. If a user has a tilemap that doesn't change often they can gain performance by setting the chunk size to be very large reducing draw calls and they can mix another tilemap layer that might update more frequently on top of the more static map. 