### PR TITLE
Fixed duplication of path in tilesheet loading

### DIFF
--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -161,14 +161,8 @@ impl AssetLoader for TiledLoader {
                         }
                     }
                     Some(img) => {
-                        // The load context path is the TMX file itself. If the file is at the root of the
-                        // assets/ directory structure then the tmx_dir will be empty, which is fine.
-                        let tmx_dir = load_context
-                            .path()
-                            .parent()
-                            .expect("The asset load context was empty.");
-                        let tile_path = tmx_dir.join(&img.source);
-                        let asset_path = AssetPath::from(tile_path);
+                        
+                        let asset_path = AssetPath::from(img.source.clone());
                         let texture: Handle<Image> = load_context.load(asset_path.clone());
 
                         TilemapTexture::Single(texture.clone())


### PR DESCRIPTION
The provided tiled load handler duplicated path for tilesheets due to it being handled as relative to the .tmx file it is used in.

Error:
```
2024-03-27T21:48:21.803906Z  INFO platformer_2d::bevy_ecs_tilemap::helpers::tiled: Loaded map: tiled/dev_env/dev_env.tmx
2024-03-27T21:48:21.803980Z ERROR bevy_asset::server: Path not found: C:\<PROJECT_PATH>\assets\tiled/dev_env\tiled/dev_env\dev_env_tilesheet.png
```

This PR removes that code and expects img.source to be correct. This was tested both with tilesheet .png in same dir as .tmx file and in a subfolder.