### PR TITLE
Hide all or tileset / layer tiles

### DIFF
--- a/examples/tiled.rs
+++ b/examples/tiled.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::*;
 
+use crate::helpers::tiled::{TiledLayersStorage, TiledMap};
+
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
@@ -31,5 +33,27 @@ fn main() {
         .add_plugins(helpers::tiled::TiledMapPlugin)
         .add_systems(Startup, startup)
         .add_systems(Update, helpers::camera::movement)
+        .add_systems(Update, hide_tiles)
         .run();
+}
+
+fn hide_tiles(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    tile_storage_query: Query<&TileStorage>,
+    mut map_query: Query<&TiledLayersStorage>,
+    mut tile_query: Query<&mut TileVisible>,
+) {
+    if keyboard_input.pressed(KeyCode::Space) {
+        for layer_storage in map_query.iter_mut() {
+            for layer_entity in layer_storage.storage.values() {
+                if let Ok(layer_tile_storage) = tile_storage_query.get(*layer_entity) {
+                    for tile in layer_tile_storage.iter().flatten() {
+                        if let Ok(mut t) = tile_query.get_mut(*tile) {
+                            t.0 = false;
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/examples/tiled.rs
+++ b/examples/tiled.rs
@@ -1,9 +1,12 @@
-use bevy::prelude::*;
+use bevy::{ecs::query::QueryFilter, prelude::*};
 use bevy_ecs_tilemap::prelude::*;
 
-use crate::helpers::tiled::{TiledLayersStorage, TiledMap};
+use crate::helpers::tiled::TilesetLayerToStorageEntity;
 
 mod helpers;
+
+#[derive(Resource, Deref, DerefMut)]
+pub struct DebouncedTimer(Timer);
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
@@ -31,28 +34,50 @@ fn main() {
         )
         .add_plugins(TilemapPlugin)
         .add_plugins(helpers::tiled::TiledMapPlugin)
+        .insert_resource(DebouncedTimer(Timer::from_seconds(0.5, TimerMode::Once)))
         .add_systems(Startup, startup)
         .add_systems(Update, helpers::camera::movement)
-        .add_systems(Update, hide_tiles)
+        .add_systems(Update, show_hide_tiles)
         .run();
 }
 
-fn hide_tiles(
+fn show_hide_tiles(
+    time: Res<Time>,
+    mut timer: ResMut<DebouncedTimer>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
     tile_storage_query: Query<&TileStorage>,
-    mut map_query: Query<&TiledLayersStorage>,
+    map_query: Query<&TilesetLayerToStorageEntity>,
     mut tile_query: Query<&mut TileVisible>,
 ) {
-    if keyboard_input.pressed(KeyCode::Space) {
-        for layer_storage in map_query.iter_mut() {
-            for layer_entity in layer_storage.storage.values() {
-                if let Ok(layer_tile_storage) = tile_storage_query.get(*layer_entity) {
-                    for tile in layer_tile_storage.iter().flatten() {
-                        if let Ok(mut t) = tile_query.get_mut(*tile) {
-                            t.0 = false;
-                        }
-                    }
-                }
+    timer.0.tick(time.delta());
+
+    if keyboard_input.pressed(KeyCode::Space) && timer.0.finished() {
+        timer.0.reset();
+        info!("Hide/Show all tiles");
+        let tileset_layer_entity = map_query.single();
+        for entity in tileset_layer_entity.get_entities() {
+            toggle_tiles_visibility(&tile_storage_query, &mut tile_query, entity);
+        }
+    }
+    if keyboard_input.pressed(KeyCode::KeyC) && timer.0.finished() {
+        timer.0.reset();
+        info!("Hide/Show castle tiles");
+        let tileset_layer_entity = map_query.single();
+        for entity in tileset_layer_entity.storage.get(&2).unwrap().values() {
+            toggle_tiles_visibility(&tile_storage_query, &mut tile_query, entity);
+        }
+    }
+}
+
+fn toggle_tiles_visibility(
+    tile_storage_query: &Query<&TileStorage>,
+    tile_query: &mut Query<&mut TileVisible>,
+    entity: &Entity,
+) {
+    if let Ok(map_tiles) = tile_storage_query.get(*entity) {
+        for tile in map_tiles.iter().flatten() {
+            if let Ok(mut t) = tile_query.get_mut(*tile) {
+                t.0 = !t.0;
             }
         }
     }


### PR DESCRIPTION
This is my first MR for this project, and it certainly deserves to be elaborated, so thank you in advance for your feedback.

Here are the explanations: 

For my needs, I wanted to hide all the tiles or only some tiles belonging to a layer in a tilemap. I noticed that the TiledLayersStorage structure only contained the tiles for the last tileset and consequently, when I wanted to hide all the tiles, those belonging to the other tilesets remained visible.
Therefore, I slightly modified the structure from a HashMap of layer --> Storage Entity to
a HashMap of HashMaps tileset --> layer -> Storage Entity.

This allows selecting all tiles, tiles of one or more tilesets, and/or one or more layers.

I updated the example in tiled.rs to demonstrate how to either hide/make visible all the tiles or just the tiles of the tileset containing the castle.