### PR TITLE
Use license instead of license-file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.12.0"
 authors = ["John Mitchell"]
 homepage = "https://github.com/StarArawn/bevy_ecs_tilemap"
 repository = "https://github.com/StarArawn/bevy_ecs_tilemap"
-license-file = "LICENSE"
+license = "MIT"
 edition = "2021"
 exclude = ["assets/*", "screenshots/*"]
 


### PR DESCRIPTION
The license-file is intended to be used for nonstandard licenses, per the cargo docs.

> If a package is using a nonstandard license, then the license-file field
> may be specified in lieu of the license field.

https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields

Closes #490 