### PR TITLE
Improve workaround for wgpu's gles texture type inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,8 @@ After that's installed and configured, run:
 #### WebGL2
 
 ```bash
-cargo run --target wasm32-unknown-unknown --example animation --features atlas
+cargo run --target wasm32-unknown-unknown --example animation
 ```
-
-**Note**: You **must** use the `atlas` feature when targeting the web with WebGL2. See [#283](https://github.com/StarArawn/bevy_ecs_tilemap/issues/283).
 
 #### WebGPU
 

--- a/src/render/texture_array_cache.rs
+++ b/src/render/texture_array_cache.rs
@@ -156,8 +156,12 @@ impl TextureArrayCache {
                     let (count, tile_size, _, _, filter, format) =
                         self.meta_data.get(texture).unwrap();
 
-                    // Fixes weird cubemap bug.
-                    let count = if *count == 6 { count + 1 } else { *count };
+                    // Fixes issue where wgpu's gles texture type inference fails.
+                    let count = if *count == 1 || count % 6 == 0 {
+                        count + 1
+                    } else {
+                        *count
+                    };
 
                     let gpu_texture = render_device.create_texture(&TextureDescriptor {
                         label: Some("texture_array"),


### PR DESCRIPTION
* Remove unnecessary feature flag (`atlas`) from WebGL2 section

~~To be honest, I can't see any difference with or without the patch. Everything seems to work fine when running the examples through `wasm-server-runner` without `--features atlas` anyway... Has the workaround been added somewhere else? (I can't find anything...)~~

Closes #395
Closes #283