### PR TITLE
Run First systems after TimeSystem in order to ensure minimum impact on delta time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! - Texture array support.
 
 use bevy::prelude::{
-    Bundle, Changed, Component, Deref, First, GlobalTransform, InheritedVisibility, Plugin, Query,
+    Bundle, Changed, Component, Deref, First, GlobalTransform, InheritedVisibility, IntoSystemConfigs, Plugin, Query,
     Reflect, ReflectComponent, Transform, ViewVisibility, Visibility,
 };
 
@@ -36,6 +36,7 @@ use tiles::{
 
 #[cfg(all(not(feature = "atlas"), feature = "render"))]
 use bevy::render::{ExtractSchedule, RenderApp};
+use bevy::time::TimeSystem;
 
 /// A module that allows pre-loading of atlases into array textures.
 #[cfg(all(not(feature = "atlas"), feature = "render"))]
@@ -58,7 +59,7 @@ impl Plugin for TilemapPlugin {
         #[cfg(feature = "render")]
         app.add_plugins(render::TilemapRenderingPlugin);
 
-        app.add_systems(First, update_changed_tile_positions);
+        app.add_systems(First, update_changed_tile_positions.after(TimeSystem));
 
         #[cfg(all(not(feature = "atlas"), feature = "render"))]
         {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -13,6 +13,7 @@ use bevy::{
         view::{check_visibility, VisibilitySystems},
         Render, RenderApp, RenderSet,
     },
+    time::TimeSystem,
     utils::HashSet,
 };
 
@@ -20,7 +21,6 @@ use bevy::{
 use bevy::render::renderer::RenderDevice;
 #[cfg(not(feature = "atlas"))]
 use bevy::render::texture::GpuImage;
-
 use crate::{
     prelude::TilemapRenderSettings,
     tiles::{TilePos, TileStorage},
@@ -113,7 +113,7 @@ impl Plugin for TilemapRenderingPlugin {
         #[cfg(not(feature = "atlas"))]
         app.add_systems(Update, set_texture_to_copy_src);
 
-        app.add_systems(First, clear_removed);
+        app.add_systems(First, clear_removed.after(TimeSystem));
         app.add_systems(PostUpdate, (removal_helper, removal_helper_tilemap));
 
         app.add_plugins(MaterialTilemapPlugin::<StandardTilemapMaterial>::default());


### PR DESCRIPTION
Systems that are added to the First schedule run before TimeSystem runs, potentially delaying proper delta time computation / frame start. 

Better solution would be to add a proper set for these systems and sort it against TimeSystem set.