### PR TITLE
Run systems in First after Time set

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,13 @@
 //! - Built in animation support  – see [`animation` example](https://github.com/StarArawn/bevy_ecs_tilemap/blob/main/examples/animation.rs).
 //! - Texture array support.
 
-use bevy::prelude::{
-    Bundle, Changed, Component, Deref, First, GlobalTransform, InheritedVisibility, Plugin, Query,
-    Reflect, ReflectComponent, Transform, ViewVisibility, Visibility,
+use bevy::{
+    prelude::{
+        Bundle, Changed, Component, Deref, First, GlobalTransform, InheritedVisibility,
+        IntoSystemConfigs, IntoSystemSetConfigs, Plugin, Query, Reflect, ReflectComponent,
+        SystemSet, Transform, ViewVisibility, Visibility,
+    },
+    time::TimeSystem,
 };
 
 #[cfg(feature = "render")]
@@ -58,7 +62,7 @@ impl Plugin for TilemapPlugin {
         #[cfg(feature = "render")]
         app.add_plugins(render::TilemapRenderingPlugin);
 
-        app.add_systems(First, update_changed_tile_positions);
+        app.add_systems(First, update_changed_tile_positions.in_set(TilemapFirstSet));
 
         #[cfg(all(not(feature = "atlas"), feature = "render"))]
         {
@@ -83,9 +87,13 @@ impl Plugin for TilemapPlugin {
             .register_type::<TileFlip>()
             .register_type::<TileStorage>()
             .register_type::<TilePosOld>()
-            .register_type::<AnimatedTile>();
+            .register_type::<AnimatedTile>()
+            .configure_sets(First, TilemapFirstSet.after(TimeSystem));
     }
 }
+
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TilemapFirstSet;
 
 #[derive(Component, Reflect, Debug, Clone, Copy, Deref)]
 #[reflect(Component)]

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -24,6 +24,7 @@ use bevy::render::texture::GpuImage;
 use crate::{
     prelude::TilemapRenderSettings,
     tiles::{TilePos, TileStorage},
+    TilemapFirstSet,
 };
 use crate::{
     prelude::TilemapTexture,
@@ -113,7 +114,7 @@ impl Plugin for TilemapRenderingPlugin {
         #[cfg(not(feature = "atlas"))]
         app.add_systems(Update, set_texture_to_copy_src);
 
-        app.add_systems(First, clear_removed);
+        app.add_systems(First, clear_removed.in_set(TilemapFirstSet));
         app.add_systems(PostUpdate, (removal_helper, removal_helper_tilemap));
 
         app.add_plugins(MaterialTilemapPlugin::<StandardTilemapMaterial>::default());


### PR DESCRIPTION
If we accept that [(#4669) Res<Time> is jittery](https://github.com/bevyengine/bevy/issues/4669) then

1. Time is updated in the [TimeSystem set](https://docs.rs/bevy/0.14.2/bevy/time/struct.TimeSystem.html)
2. No work should happen before the Time is updated in a frame

This doesn't fix the upstream jitter issue, but we can reduce bevy_ecs_tilemap's potential impact on the issue by making sure any work we do in `First` is done *after* time is updated.

## Solution

1. Create a new `TilemapFirstSet` SystemSet
2. Add bevy_ecs_tilemap `First` systems to `TilemapFirstSet`
3. Order `TilemapFirstSet` systems after the `TimeSystem`.

## bevy_mod_debug_dump

system scheduling in First before change:

![screenshot-2024-09-15-at-10 15 37@2x](https://github.com/user-attachments/assets/8c3f1808-6e07-496d-8c30-c71f4e18a836)

system scheduling after change:

![screenshot-2024-09-15-at-10 18 23@2x](https://github.com/user-attachments/assets/d5fe6123-35ca-4e28-bada-bcd23169a9ee)


## Migration

This shouldn't require end-user migration, but if you want to run system in First after bevy_ecs_tilemap's work, then the new SystemSet should be used.