### PR TITLE
Derive `Ord` for `TilePos`

### DIFF
--- a/src/tiles/mod.rs
+++ b/src/tiles/mod.rs
@@ -10,7 +10,7 @@ use crate::map::TilemapId;
 use crate::TilemapSize;
 
 /// A tile position in the tilemap grid.
-#[derive(Component, Reflect, Default, Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd)]
+#[derive(Component, Reflect, Default, Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[reflect(Component)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TilePos {


### PR DESCRIPTION
`TilePos` has a total order. See https://doc.rust-lang.org/stable/core/cmp/trait.Ord.html#corollaries

This allows using `TilePos` as key in `BTreeMap` or as value in `BTreeSet`, for example.