### PR TITLE
0.15 (sort of)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ render = []
 serde = ["dep:serde"]
 
 [dependencies]
-bevy = { version = "0.15.0-rc.1", default-features = false, features = [
+bevy = { version = "0.15.0-rc.2", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",
@@ -34,7 +34,7 @@ tiled = { version = "0.11.0", default-features = false }
 thiserror = { version = "1.0" }
 
 [dev-dependencies.bevy]
-version = "0.15.0-rc.1"
+version = "0.15.0-rc.2"
 default-features = false
 features = [
     "bevy_core_pipeline",
@@ -51,7 +51,7 @@ features = [
 ]
 
 [target.'cfg(unix)'.dev-dependencies.bevy]
-version = "0.15.0-rc.1"
+version = "0.15.0-rc.2"
 default-features = false
 features = [
     "bevy_core_pipeline",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ render = []
 serde = ["dep:serde"]
 
 [dependencies]
-bevy = { version = "0.14.0", default-features = false, features = [
+bevy = { version = "0.15.0-rc.1", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ render = []
 serde = ["dep:serde"]
 
 [dependencies]
-bevy = { version = "0.15.0-rc.2", default-features = false, features = [
+bevy = { version = "0.15.0-rc.3", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",
@@ -34,7 +34,7 @@ tiled = { version = "0.11.0", default-features = false }
 thiserror = { version = "1.0" }
 
 [dev-dependencies.bevy]
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 default-features = false
 features = [
     "bevy_core_pipeline",
@@ -51,7 +51,7 @@ features = [
 ]
 
 [target.'cfg(unix)'.dev-dependencies.bevy]
-version = "0.15.0-rc.2"
+version = "0.15.0-rc.3"
 default-features = false
 features = [
     "bevy_core_pipeline",

--- a/examples/3d_iso.rs
+++ b/examples/3d_iso.rs
@@ -4,20 +4,20 @@ use bevy_ecs_tilemap::prelude::*;
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
-    let map_handle: Handle<helpers::tiled::TiledMap> = asset_server.load("iso_map.tmx");
+    let map_handle: helpers::tiled::TiledMapAssetHandle = asset_server.load("iso_map.tmx").into();
 
-    commands.spawn(helpers::tiled::TiledMapBundle {
-        tiled_map: map_handle,
-        render_settings: TilemapRenderSettings {
+    commands.spawn((
+        helpers::tiled::TiledMap,
+        map_handle,
+        TilemapRenderSettings {
             // Map size is 12x12 so we'll have render chunks that are:
             // 12 tiles wide and 1 tile tall.
             render_chunk_size: UVec2::new(3, 1),
             y_sort: true,
         },
-        ..Default::default()
-    });
+    ));
 }
 
 fn main() {

--- a/examples/accessing_tiles.rs
+++ b/examples/accessing_tiles.rs
@@ -109,7 +109,7 @@ fn update_map(
     )>,
     mut tile_query: Query<&mut TileTextureIndex>,
 ) {
-    let current_time = time.elapsed_seconds_f64();
+    let current_time = time.elapsed_secs_f64();
     for (mut current_color, mut last_update, tile_storage, map_size) in tilemap_query.iter_mut() {
         if current_time - last_update.0 > 0.1 {
             current_color.0 += 1;

--- a/examples/accessing_tiles.rs
+++ b/examples/accessing_tiles.rs
@@ -11,7 +11,7 @@ struct CurrentColor(u16);
 struct LastUpdate(f64);
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
 
@@ -83,16 +83,14 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Spawns a tilemap.
     // Once the tile storage is inserted onto the tilemap entity it can no longer be accessed.
     commands.entity(tilemap_entity).insert((
-        TilemapBundle {
-            grid_size,
-            size: map_size,
-            storage: tile_storage,
-            map_type,
-            texture: TilemapTexture::Single(texture_handle),
-            tile_size,
-            transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-            ..Default::default()
-        },
+        Tilemap,
+        grid_size,
+        map_size,
+        tile_storage,
+        map_type,
+        TilemapTexture::Single(texture_handle),
+        tile_size,
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
         LastUpdate(0.0),
         CurrentColor(1),
     ));

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -53,16 +53,16 @@ fn create_background(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         size,
         grid_size,
         map_type,
         tile_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
-        transform: get_tilemap_center_transform(&size, &grid_size, &map_type, 0.0),
-        ..Default::default()
-    });
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        get_tilemap_center_transform(&size, &grid_size, &map_type, 0.0),
+    ));
 }
 
 fn create_animated_flowers(mut commands: Commands, asset_server: Res<AssetServer>) {
@@ -110,20 +110,20 @@ fn create_animated_flowers(mut commands: Commands, asset_server: Res<AssetServer
     }
     let map_type = TilemapType::Square;
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
-        size: map_size,
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
+        map_size,
         grid_size,
         map_type,
         tile_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 1.0),
-        ..Default::default()
-    });
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 1.0),
+    ));
 }
 
 fn startup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 }
 
 fn main() {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -10,7 +10,7 @@ fn startup(
         ArrayTextureLoader,
     >,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
 
@@ -49,16 +49,16 @@ fn startup(
     let grid_size = tile_size.into();
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
         tile_size,
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-        ..Default::default()
-    });
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+    ));
 
     // Add atlas to array texture loader so it's preprocessed before we need to use it.
     // Only used when the atlas feature is off and we are using array textures.

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -7,7 +7,7 @@ use bevy_ecs_tilemap::prelude::*;
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
 
@@ -27,20 +27,20 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let grid_size = tile_size.into();
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
         tile_size,
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-        render_settings: TilemapRenderSettings {
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+        TilemapRenderSettings {
             render_chunk_size: UVec2::new(256, 256),
             ..Default::default()
         },
-        ..Default::default()
-    });
+    ));
 }
 
 fn main() {

--- a/examples/chunking.rs
+++ b/examples/chunking.rs
@@ -38,23 +38,23 @@ fn spawn_chunk(commands: &mut Commands, asset_server: &AssetServer, chunk_pos: I
         0.0,
     ));
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
-    commands.entity(tilemap_entity).insert(TilemapBundle {
-        grid_size: TILE_SIZE.into(),
-        size: CHUNK_SIZE.into(),
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
-        tile_size: TILE_SIZE,
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
+        TILE_SIZE,
+        TilemapSize::new(CHUNK_SIZE.x, CHUNK_SIZE.y),
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TILE_SIZE,
         transform,
-        render_settings: TilemapRenderSettings {
+        TilemapRenderSettings {
             render_chunk_size: RENDER_CHUNK_SIZE,
             ..Default::default()
         },
-        ..Default::default()
-    });
+    ));
 }
 
 fn startup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 }
 
 fn camera_pos_to_chunk_pos(camera_pos: &Vec2) -> IVec2 {

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -7,7 +7,7 @@ mod helpers;
 const QUADRANT_SIDE_LENGTH: u32 = 64;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
 
@@ -78,16 +78,16 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let grid_size = tile_size.into();
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
         tile_size,
-        map_type: TilemapType::Square,
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-        ..Default::default()
-    });
+        TilemapType::Square,
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+    ));
 }
 
 fn main() {

--- a/examples/custom_shader.rs
+++ b/examples/custom_shader.rs
@@ -1,5 +1,5 @@
 use bevy::{prelude::*, reflect::TypePath, render::render_resource::AsBindGroup};
-use bevy_ecs_tilemap::prelude::*;
+use bevy_ecs_tilemap::{prelude::*, MaterialTilemap};
 mod helpers;
 
 #[derive(AsBindGroup, TypePath, Debug, Clone, Default, Asset)]
@@ -49,19 +49,18 @@ fn startup(
     let grid_size = tile_size.into();
     let map_type = TilemapType::default();
 
-    commands
-        .entity(tilemap_entity)
-        .insert(MaterialTilemapBundle {
-            grid_size,
-            map_type,
-            size: map_size,
-            storage: tile_storage,
-            texture: TilemapTexture::Single(texture_handle.clone()),
-            tile_size,
-            transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-            material: my_material_handle.clone(),
-            ..Default::default()
-        });
+    commands.entity(tilemap_entity).insert((
+        // TODO: is this actually what we want here?
+        MaterialTilemap::<MyMaterial>(std::marker::PhantomData),
+        grid_size,
+        map_type,
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle.clone()),
+        tile_size,
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+        my_material_handle.clone(),
+    ));
 
     // Layer 2
     let mut tile_storage = TileStorage::empty(map_size);
@@ -75,20 +74,18 @@ fn startup(
         &mut tile_storage,
     );
 
-    commands
-        .entity(tilemap_entity)
-        .insert(MaterialTilemapBundle {
-            grid_size,
-            map_type,
-            size: map_size,
-            storage: tile_storage,
-            texture: TilemapTexture::Single(texture_handle),
-            tile_size: TilemapTileSize { x: 16.0, y: 16.0 },
-            transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 1.0)
-                * Transform::from_xyz(32.0, 32.0, 0.0),
-            material: my_material_handle,
-            ..Default::default()
-        });
+    commands.entity(tilemap_entity).insert((
+        MaterialTilemap::<MyMaterial>(std::marker::PhantomData),
+        grid_size,
+        map_type,
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapTileSize { x: 16.0, y: 16.0 },
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 1.0)
+            * Transform::from_xyz(32.0, 32.0, 0.0),
+        my_material_handle,
+    ));
 }
 
 fn main() {
@@ -105,7 +102,7 @@ fn main() {
                 .set(ImagePlugin::default_nearest()),
         )
         .add_plugins(TilemapPlugin)
-        .add_plugins(MaterialTilemapPlugin::<MyMaterial>::default())
+        .add_plugins(TilemapMaterialPlugin::<MyMaterial>::default())
         .add_systems(Startup, startup)
         .add_systems(Update, helpers::camera::movement)
         .run();

--- a/examples/custom_shader.rs
+++ b/examples/custom_shader.rs
@@ -11,7 +11,7 @@ pub struct MyMaterial {
     _padding: Vec3,
 }
 
-impl MaterialTilemap for MyMaterial {
+impl TilemapMaterial for MyMaterial {
     fn fragment_shader() -> bevy::render::render_resource::ShaderRef {
         "custom_shader.wgsl".into()
     }
@@ -22,12 +22,12 @@ fn startup(
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<MyMaterial>>,
 ) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
-    let my_material_handle = materials.add(MyMaterial {
+    let my_material_handle = TilemapMaterialHandle(materials.add(MyMaterial {
         brightness: 0.5,
         ..default()
-    });
+    }));
 
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
 

--- a/examples/frustum_cull_test.rs
+++ b/examples/frustum_cull_test.rs
@@ -75,7 +75,7 @@ impl FromWorld for FontHandle {
 
 // Generates the initial tilemap, which is a square grid.
 fn spawn_tilemap(mut commands: Commands, tile_handle_square: Res<TileHandleSquare>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let map_size = TilemapSize {
         // Render chunks are of size 64, so let's create two render chunks
@@ -98,18 +98,18 @@ fn spawn_tilemap(mut commands: Commands, tile_handle_square: Res<TileHandleSquar
     let tile_size = TILE_SIZE_SQUARE;
     let grid_size = GRID_SIZE_SQUARE;
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(tile_handle_square.clone()),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(tile_handle_square.clone()),
         tile_size,
-        map_type: TilemapType::Square,
+        TilemapType::Square,
         // The default behaviour is `FrustumCulling(true)`, but we supply this explicitly here
         // for the purposes of the example.
-        frustum_culling: FrustumCulling(true),
-        ..Default::default()
-    });
+        FrustumCulling(true),
+    ));
 }
 
 #[derive(Component)]
@@ -122,13 +122,6 @@ fn spawn_map_type_label(
     windows: Query<&Window>,
     map_type_q: Query<&TilemapType>,
 ) {
-    let text_style = TextStyle {
-        font: font_handle.clone(),
-        font_size: 20.0,
-        color: Color::BLACK,
-    };
-    let text_justify = JustifyText::Center;
-
     for window in windows.iter() {
         for map_type in map_type_q.iter() {
             // Place the map type label somewhere in the top left side of the screen
@@ -138,12 +131,18 @@ fn spawn_map_type_label(
                 ..Default::default()
             };
             commands.spawn((
-                Text2dBundle {
-                    text: Text::from_section(format!("{map_type:?}"), text_style.clone())
-                        .with_justify(text_justify),
-                    transform,
+                Text2d::new(format!("{map_type:?}")),
+                TextFont {
+                    font: font_handle.clone(),
+                    font_size: 20.0,
                     ..default()
                 },
+                TextColor(Color::BLACK),
+                TextLayout {
+                    justify: JustifyText::Center,
+                    ..default()
+                },
+                transform,
                 MapTypeLabel,
             ));
         }
@@ -160,7 +159,7 @@ fn swap_map_type(
         &mut TilemapTileSize,
     )>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
-    mut map_type_label_q: Query<&mut Text, With<MapTypeLabel>>,
+    mut map_type_label_q: Query<&mut Text2d, With<MapTypeLabel>>,
     tile_handle_square: Res<TileHandleSquare>,
     tile_handle_hex_row: Res<TileHandleHexRow>,
     tile_handle_hex_col: Res<TileHandleHexCol>,
@@ -216,7 +215,7 @@ fn swap_map_type(
             }
 
             for mut label_text in map_type_label_q.iter_mut() {
-                label_text.sections[0].value = format!("{:?}", map_type.as_ref());
+                label_text.0 = format!("{:?}", map_type.as_ref());
             }
         }
     }

--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -5,7 +5,7 @@ use bevy_ecs_tilemap::prelude::*;
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
 
@@ -35,16 +35,14 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let map_type = TilemapType::Square;
 
     commands.entity(tilemap_entity).insert((
-        TilemapBundle {
-            grid_size,
-            map_type,
-            size: map_size,
-            storage: tile_storage,
-            texture: TilemapTexture::Single(texture_handle),
-            tile_size,
-            transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-            ..Default::default()
-        },
+        Tilemap,
+        grid_size,
+        map_type,
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        tile_size,
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
         LastUpdate(0.0),
     ));
 }

--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -58,7 +58,7 @@ fn update(
     mut tile_storage_query: Query<(&TileStorage, &TilemapSize, &mut LastUpdate)>,
     tile_query: Query<(Entity, &TilePos, &TileVisible)>,
 ) {
-    let current_time = time.elapsed_seconds_f64();
+    let current_time = time.elapsed_secs_f64();
     let (tile_storage, map_size, mut last_update) = tile_storage_query.single_mut();
     if current_time - last_update.0 > 0.1 {
         for (entity, position, visibility) in tile_query.iter() {

--- a/examples/helpers/camera.rs
+++ b/examples/helpers/camera.rs
@@ -39,7 +39,7 @@ pub fn movement(
         }
 
         let z = transform.translation.z;
-        transform.translation += time.delta_seconds() * direction * 500.;
+        transform.translation += time.delta_secs() * direction * 500.;
         // Important! We need to restore the Z values when moving the camera around.
         // Bevy has a specific camera setup and this can mess with how our layers are shown.
         transform.translation.z = z;

--- a/examples/helpers/ldtk.rs
+++ b/examples/helpers/ldtk.rs
@@ -254,7 +254,7 @@ pub fn process_loaded_tile_maps(
 
                         // Create the tilemap
                         commands.entity(map_entity).insert((
-                            Tilemap::default(),
+                            Tilemap,
                             grid_size,
                             map_type,
                             size,

--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -20,7 +20,7 @@ use bevy::prelude::*;
 use bevy::reflect::Reflect;
 use bevy::render::extract_component::ExtractComponent;
 use bevy::{
-    asset::{io::Reader, AssetLoader, AssetPath, AsyncReadExt},
+    asset::{io::Reader, AssetLoader, AssetPath},
     log,
     prelude::{
         Added, Asset, AssetApp, AssetEvent, AssetId, Assets, Commands, Component,
@@ -30,7 +30,7 @@ use bevy::{
     reflect::TypePath,
     utils::HashMap,
 };
-use bevy_ecs_tilemap::{prelude::*, MaterialTilemap};
+use bevy_ecs_tilemap::prelude::*;
 
 use thiserror::Error;
 
@@ -403,7 +403,7 @@ pub fn process_loaded_maps(
                         }
 
                         commands.entity(layer_entity).insert((
-                            MaterialTilemap::<StandardTilemapMaterial>::new(),
+                            Tilemap::default(),
                             grid_size,
                             map_size,
                             tile_storage,

--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -61,7 +61,7 @@ pub struct TiledLayersStorage {
 
 #[derive(Default, Bundle)]
 pub struct TiledMapBundle {
-    pub tiled_map: Handle<TiledMap>,
+    pub tiled_map: TilemapMaterialHandle<TiledMap>,
     pub storage: TiledLayersStorage,
     pub transform: Transform,
     pub global_transform: GlobalTransform,

--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -403,7 +403,7 @@ pub fn process_loaded_maps(
                         }
 
                         commands.entity(layer_entity).insert((
-                            Tilemap::default(),
+                            Tilemap,
                             grid_size,
                             map_size,
                             tile_storage,

--- a/examples/hexagon_column.rs
+++ b/examples/hexagon_column.rs
@@ -7,7 +7,7 @@ mod helpers;
 const QUADRANT_SIDE_LENGTH: u32 = 80;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("flat_hex_tiles.png");
 
@@ -74,16 +74,16 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let grid_size = TilemapGridSize { x: 17.0, y: 15.0 };
     let map_type = TilemapType::Hexagon(HexCoordSystem::Column);
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
         tile_size,
         map_type,
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-        ..Default::default()
-    });
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+    ));
 }
 
 fn swap_mesh_type(

--- a/examples/hexagon_row.rs
+++ b/examples/hexagon_row.rs
@@ -6,7 +6,7 @@ mod helpers;
 const QUADRANT_SIDE_LENGTH: u32 = 80;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("pointy_hex_tiles.png");
 
@@ -73,16 +73,16 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let grid_size = TilemapGridSize { x: 15.0, y: 17.0 };
     let map_type = TilemapType::Hexagon(HexCoordSystem::Row);
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
         tile_size,
         map_type,
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-        ..Default::default()
-    });
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+    ));
 }
 
 fn swap_mesh_type(

--- a/examples/iso_diamond.rs
+++ b/examples/iso_diamond.rs
@@ -8,7 +8,7 @@ mod helpers;
 const QUADRANT_SIDE_LENGTH: u32 = 80;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("iso_color.png");
 
@@ -74,16 +74,16 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let grid_size = tile_size.into();
     let map_type = TilemapType::Isometric(IsoCoordSystem::Diamond);
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
         tile_size,
         map_type,
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-        ..Default::default()
-    });
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+    ));
 }
 
 fn main() {

--- a/examples/iso_staggered.rs
+++ b/examples/iso_staggered.rs
@@ -10,7 +10,7 @@ mod helpers;
 const QUADRANT_SIDE_LENGTH: u32 = 80;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("iso_color.png");
 
@@ -76,16 +76,16 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let grid_size = tile_size.into();
     let map_type = TilemapType::Isometric(IsoCoordSystem::Staggered);
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
         tile_size,
         map_type,
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-        ..Default::default()
-    });
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+    ));
 }
 
 fn main() {

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -3,7 +3,7 @@ use bevy_ecs_tilemap::prelude::*;
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
 
@@ -25,16 +25,16 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let grid_size = tile_size.into();
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle.clone()),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle.clone()),
         tile_size,
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-        ..Default::default()
-    });
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+    ));
 
     // Layer 2
     let mut tile_storage = TileStorage::empty(map_size);
@@ -48,17 +48,17 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         &mut tile_storage,
     );
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
-        tile_size: TilemapTileSize { x: 16.0, y: 16.0 },
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 1.0)
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapTileSize { x: 16.0, y: 16.0 },
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 1.0)
             * Transform::from_xyz(32.0, 32.0, 0.0),
-        ..Default::default()
-    });
+    ));
 }
 
 fn main() {

--- a/examples/ldtk.rs
+++ b/examples/ldtk.rs
@@ -14,15 +14,15 @@ use bevy_ecs_tilemap::*;
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
-    let handle: Handle<helpers::ldtk::LdtkMap> = asset_server.load("map.ldtk");
+    let handle: helpers::ldtk::LdtkMapAssetHandle = asset_server.load("map.ldtk").into();
 
-    commands.spawn(helpers::ldtk::LdtkMapBundle {
-        ldtk_map: handle,
-        transform: Transform::from_xyz(0.0, 0.0, 0.0),
-        ..Default::default()
-    });
+    commands.spawn((
+        helpers::ldtk::LdtkMap,
+        handle,
+        Transform::from_xyz(0.0, 0.0, 0.0),
+    ));
 }
 
 fn main() {

--- a/examples/mouse_to_tile.rs
+++ b/examples/mouse_to_tile.rs
@@ -72,7 +72,7 @@ impl FromWorld for FontHandle {
 
 // Generates the initial tilemap, which is a square grid.
 fn spawn_tilemap(mut commands: Commands, tile_handle_square: Res<TileHandleSquare>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let map_size = TilemapSize {
         x: MAP_SIDE_LENGTH_X,
@@ -95,16 +95,16 @@ fn spawn_tilemap(mut commands: Commands, tile_handle_square: Res<TileHandleSquar
     let grid_size = GRID_SIZE_SQUARE;
     let map_type = TilemapType::Square;
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(tile_handle_square.clone()),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(tile_handle_square.clone()),
         tile_size,
         map_type,
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-        ..Default::default()
-    });
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+    ));
 }
 
 #[derive(Component)]

--- a/examples/move_tile.rs
+++ b/examples/move_tile.rs
@@ -3,7 +3,7 @@ use bevy_ecs_tilemap::prelude::*;
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
 
@@ -30,16 +30,16 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let grid_size = tile_size.into();
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
         tile_size,
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-        ..Default::default()
-    });
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+    ));
 }
 
 fn swap_pos(keyboard_input: Res<ButtonInput<KeyCode>>, mut query: Query<&mut TilePos>) {

--- a/examples/random_map.rs
+++ b/examples/random_map.rs
@@ -57,7 +57,7 @@ struct LastUpdate {
 // In this example it's better not to use the default `MapQuery` SystemParam as
 // it's faster to do it this way:
 fn random(time: ResMut<Time>, mut query: Query<(&mut TileTextureIndex, &mut LastUpdate)>) {
-    let current_time = time.elapsed_seconds_f64();
+    let current_time = time.elapsed_secs_f64();
     let mut random = thread_rng();
     for (mut tile, mut last_update) in query.iter_mut() {
         if (current_time - last_update.value) > 0.2 {

--- a/examples/random_map.rs
+++ b/examples/random_map.rs
@@ -8,7 +8,7 @@ use rand::{thread_rng, Rng};
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
 
@@ -37,16 +37,16 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let grid_size = tile_size.into();
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
         tile_size,
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-        ..Default::default()
-    });
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+    ));
 }
 
 #[derive(Default, Component)]

--- a/examples/remove_tiles.rs
+++ b/examples/remove_tiles.rs
@@ -56,7 +56,7 @@ fn remove_tiles(
     time: Res<Time>,
     mut last_update_query: Query<(&mut LastUpdate, &mut TileStorage)>,
 ) {
-    let current_time = time.elapsed_seconds_f64();
+    let current_time = time.elapsed_secs_f64();
     for (mut last_update, mut tile_storage) in last_update_query.iter_mut() {
         // Remove a tile every half second.
         if (current_time - last_update.value) > 0.1 {

--- a/examples/remove_tiles.rs
+++ b/examples/remove_tiles.rs
@@ -5,7 +5,7 @@ use rand::{thread_rng, Rng};
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
 
@@ -32,16 +32,14 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let map_type = TilemapType::default();
 
     commands.entity(tilemap_entity).insert((
-        TilemapBundle {
-            grid_size,
-            map_type,
-            size: map_size,
-            storage: tile_storage,
-            texture: TilemapTexture::Single(texture_handle),
-            tile_size,
-            transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-            ..Default::default()
-        },
+        Tilemap,
+        grid_size,
+        map_type,
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        tile_size,
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
         LastUpdate::default(),
     ));
 }

--- a/examples/spacing.rs
+++ b/examples/spacing.rs
@@ -3,7 +3,7 @@ use bevy_ecs_tilemap::prelude::*;
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("tiles-spaced.png");
 
@@ -25,17 +25,17 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let grid_size = tile_size.into();
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle.clone()),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle.clone()),
         tile_size,
-        spacing: TilemapSpacing { x: 8.0, y: 8.0 },
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-        ..Default::default()
-    });
+        TilemapSpacing { x: 8.0, y: 8.0 },
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+    ));
 
     // Layer 2
     let mut tile_storage = TileStorage::empty(map_size);
@@ -49,17 +49,17 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         &mut tile_storage,
     );
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
-        tile_size: TilemapTileSize { x: 16.0, y: 16.0 },
-        transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 1.0)
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapTileSize { x: 16.0, y: 16.0 },
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 1.0)
             * Transform::from_xyz(32.0, 32.0, 0.0),
-        ..Default::default()
-    });
+    ));
 }
 
 fn main() {

--- a/examples/texture_container.rs
+++ b/examples/texture_container.rs
@@ -20,7 +20,7 @@ mod no_atlas {
 
     #[cfg(not(feature = "atlas"))]
     fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-        commands.spawn(Camera2dBundle::default());
+        commands.spawn(Camera2d);
 
         // Most of the work is happening bevy side. In this case, using the `ktx2` feature. If this
         // feature is not turned on, that the image won't properly be interpreted as a texture
@@ -76,16 +76,16 @@ mod no_atlas {
         let grid_size = TILE_SIZE.into();
         let map_type = TilemapType::Hexagon(COORD_SYS);
 
-        commands.entity(tilemap_entity).insert(TilemapBundle {
+        commands.entity(tilemap_entity).insert((
+            Tilemap,
             grid_size,
             map_type,
             tile_size,
-            size: map_size,
-            storage: tile_storage,
-            texture: texture_vec,
-            transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-            ..Default::default()
-        });
+            map_size,
+            tile_storage,
+            texture_vec,
+            get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+        ));
     }
 
     pub fn main() {

--- a/examples/texture_vec.rs
+++ b/examples/texture_vec.rs
@@ -19,7 +19,7 @@ mod no_atlas {
     const COORD_SYS: HexCoordSystem = HexCoordSystem::Row;
 
     fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-        commands.spawn(Camera2dBundle::default());
+        commands.spawn(Camera2d);
 
         let image_handles = vec![
             asset_server.load("hex-tile-0.png"),
@@ -70,16 +70,16 @@ mod no_atlas {
         let grid_size = TILE_SIZE.into();
         let map_type = TilemapType::Hexagon(COORD_SYS);
 
-        commands.entity(tilemap_entity).insert(TilemapBundle {
+        commands.entity(tilemap_entity).insert((
+            Tilemap,
             grid_size,
             map_type,
             tile_size,
-            size: map_size,
-            storage: tile_storage,
-            texture: texture_vec,
-            transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-            ..Default::default()
-        });
+            map_size,
+            tile_storage,
+            texture_vec,
+            get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
+        ));
     }
 
     pub fn main() {

--- a/examples/tiled.rs
+++ b/examples/tiled.rs
@@ -4,14 +4,11 @@ use bevy_ecs_tilemap::prelude::*;
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
-    let map_handle: Handle<helpers::tiled::TiledMap> = asset_server.load("map.tmx");
+    let map_handle: helpers::tiled::TiledMapAssetHandle = asset_server.load("map.tmx").into();
 
-    commands.spawn(helpers::tiled::TiledMapBundle {
-        tiled_map: map_handle,
-        ..Default::default()
-    });
+    commands.spawn((helpers::tiled::TiledMap, map_handle));
 }
 
 fn main() {

--- a/examples/tiled_rotated.rs
+++ b/examples/tiled_rotated.rs
@@ -1,17 +1,15 @@
 use bevy::prelude::*;
 use bevy_ecs_tilemap::prelude::*;
+use helpers::tiled::TiledMapAssetHandle;
 
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
-    let map_handle: Handle<helpers::tiled::TiledMap> = asset_server.load("rotate.tmx");
+    let map_handle: TiledMapAssetHandle = asset_server.load("rotate.tmx").into();
 
-    commands.spawn(helpers::tiled::TiledMapBundle {
-        tiled_map: map_handle,
-        ..Default::default()
-    });
+    commands.spawn((helpers::tiled::TiledMap, map_handle));
 }
 
 fn main() {

--- a/examples/visibility.rs
+++ b/examples/visibility.rs
@@ -56,7 +56,7 @@ fn remove_tiles(
     mut last_update_query: Query<(&mut LastUpdate, &TileStorage)>,
     mut tile_query: Query<&mut TileVisible>,
 ) {
-    let current_time = time.elapsed_seconds_f64();
+    let current_time = time.elapsed_secs_f64();
     for (mut last_update, tile_storage) in last_update_query.iter_mut() {
         // Remove a tile every half second.
         if (current_time - last_update.value) > 0.1 {

--- a/examples/visibility.rs
+++ b/examples/visibility.rs
@@ -5,7 +5,7 @@ use rand::{thread_rng, Rng};
 mod helpers;
 
 fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
 
@@ -32,16 +32,14 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let map_type = TilemapType::default();
 
     commands.entity(tilemap_entity).insert((
-        TilemapBundle {
-            grid_size,
-            map_type,
-            size: map_size,
-            storage: tile_storage,
-            texture: TilemapTexture::Single(texture_handle),
-            tile_size,
-            transform: get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
-            ..Default::default()
-        },
+        Tilemap,
+        grid_size,
+        map_type,
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        tile_size,
+        get_tilemap_center_transform(&map_size, &grid_size, &map_type, 0.0),
         LastUpdate::default(),
     ));
 }

--- a/src/helpers/filling.rs
+++ b/src/helpers/filling.rs
@@ -5,7 +5,7 @@ use crate::prelude::HexCoordSystem;
 use crate::tiles::{TileBundle, TileColor, TilePos, TileTextureIndex};
 use crate::{TileStorage, TilemapSize};
 use bevy::hierarchy::BuildChildren;
-use bevy::prelude::{Color, Commands};
+use bevy::prelude::{ChildBuild, Color, Commands};
 
 /// Fills an entire tile storage with the given tile.
 pub fn fill_tilemap(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,8 +138,8 @@ pub type Tilemap = MaterialTilemap<StandardTilemapMaterial>;
 /// The default tilemap, with custom Material rendering support.
 pub struct MaterialTilemap<M: TilemapMaterial>(PhantomData<M>);
 
-impl<M: TilemapMaterial> MaterialTilemap<M> {
-    pub fn new() -> Self {
+impl<M: TilemapMaterial> Default for MaterialTilemap<M> {
+    fn default() -> Self {
         MaterialTilemap(PhantomData)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use bevy::{
 };
 
 #[cfg(feature = "render")]
-use bevy::prelude::Handle;
+use render::material::MaterialTilemapHandle;
 
 use map::{
     TilemapGridSize, TilemapSize, TilemapSpacing, TilemapTexture, TilemapTextureSize,
@@ -131,7 +131,7 @@ pub struct MaterialTilemapBundle<M: MaterialTilemap> {
     pub view_visibility: ViewVisibility,
     /// User indication of whether tilemap should be frustum culled.
     pub frustum_culling: FrustumCulling,
-    pub material: Handle<M>,
+    pub material: MaterialTilemapHandle<M>,
 }
 
 #[cfg(not(feature = "render"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,9 +112,9 @@ impl Default for FrustumCulling {
 )]
 pub type TilemapBundle = MaterialTilemapBundle<StandardTilemapMaterial>;
 
-// TODO: there may not be any point to this, since we cannot construct the type using it.
 #[cfg(feature = "render")]
 pub type Tilemap = MaterialTilemap<StandardTilemapMaterial>;
+pub const Tilemap: Tilemap = MaterialTilemap::<StandardTilemapMaterial>(PhantomData);
 
 #[cfg(feature = "render")]
 #[derive(Component, Clone, Debug)]
@@ -136,7 +136,7 @@ pub type Tilemap = MaterialTilemap<StandardTilemapMaterial>;
     Visibility,
 )]
 /// The default tilemap, with custom Material rendering support.
-pub struct MaterialTilemap<M: TilemapMaterial>(PhantomData<M>);
+pub struct MaterialTilemap<M: TilemapMaterial>(pub PhantomData<M>);
 
 impl<M: TilemapMaterial> Default for MaterialTilemap<M> {
     fn default() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![expect(deprecated)]
 
 //! Bevy ECS Tilemap plugin is a ECS driven tilemap rendering library. It's designed to be fast and highly customizable. Each tile is considered a unique entity and all tiles are stored in the game world.
 //!
@@ -24,15 +25,13 @@ use bevy::{
 };
 
 #[cfg(feature = "render")]
-use render::material::MaterialTilemapHandle;
-
 use map::{
     TilemapGridSize, TilemapSize, TilemapSpacing, TilemapTexture, TilemapTextureSize,
     TilemapTileSize, TilemapType,
 };
 use prelude::{TilemapId, TilemapRenderSettings};
-#[cfg(feature = "render")]
-use render::material::{MaterialTilemap, StandardTilemapMaterial};
+use render::material::{StandardTilemapMaterial, TilemapMaterial, TilemapMaterialHandle};
+use std::marker::PhantomData;
 use tiles::{
     AnimatedTile, TileColor, TileFlip, TilePos, TilePosOld, TileStorage, TileTextureIndex,
     TileVisible,
@@ -107,12 +106,45 @@ impl Default for FrustumCulling {
 }
 
 #[cfg(feature = "render")]
+#[deprecated(
+    since = "0.15.0",
+    note = "Use the `MaterialTilemap` component instead. Inserting it will now automatically insert the other components it requires."
+)]
 pub type TilemapBundle = MaterialTilemapBundle<StandardTilemapMaterial>;
 
 #[cfg(feature = "render")]
-/// The default tilemap bundle. All of the components within are required.
+pub type Tilemap = MaterialTilemap<StandardTilemapMaterial>;
+
+#[cfg(feature = "render")]
+#[derive(Component, Clone, Debug)]
+#[require(
+    FrustumCulling,
+    GlobalTransform,
+    InheritedVisibility,
+    TilemapMaterialHandle<M>,
+    TileStorage,
+    TilemapGridSize,
+    TilemapRenderSettings,
+    TilemapSize,
+    TilemapSpacing,
+    TilemapTexture,
+    TilemapTileSize,
+    TilemapType,
+    Transform,
+    ViewVisibility,
+    Visibility,
+)]
+/// The default tilemap, with custom Material rendering support.
+pub struct MaterialTilemap<M: TilemapMaterial>(PhantomData<M>);
+
+#[cfg(feature = "render")]
+#[deprecated(
+    since = "0.15.0",
+    note = "Use the `MaterialTilemap` component instead. Inserting it will now automatically insert the other components it requires."
+)]
 #[derive(Bundle, Debug, Default, Clone)]
-pub struct MaterialTilemapBundle<M: MaterialTilemap> {
+/// The default tilemap, with custom Material rendering support.
+pub struct MaterialTilemapBundle<M: TilemapMaterial> {
     pub grid_size: TilemapGridSize,
     pub map_type: TilemapType,
     pub size: TilemapSize,
@@ -131,12 +163,37 @@ pub struct MaterialTilemapBundle<M: MaterialTilemap> {
     pub view_visibility: ViewVisibility,
     /// User indication of whether tilemap should be frustum culled.
     pub frustum_culling: FrustumCulling,
-    pub material: MaterialTilemapHandle<M>,
+    pub material: TilemapMaterialHandle<M>,
 }
 
 #[cfg(not(feature = "render"))]
-/// The default tilemap bundle. All of the components within are required.
+#[derive(Component, Clone, Debug)]
+#[require(
+    FrustumCulling,
+    GlobalTransform,
+    InheritedVisibility,
+    TileStorage,
+    TilemapGridSize,
+    TilemapRenderSettings,
+    TilemapSize,
+    TilemapSpacing,
+    TilemapTexture,
+    TilemapTileSize,
+    TilemapType,
+    Transform,
+    ViewVisibility,
+    Visibility
+)]
+/// The default tilemap.
+pub struct StandardTilemap;
+
+#[cfg(not(feature = "render"))]
+#[deprecated(
+    since = "0.15.0",
+    note = "Use the `StandardTilemap` component instead. Inserting it will now automatically insert the other components it requires."
+)]
 #[derive(Bundle, Debug, Default, Clone)]
+/// The default tilemap.
 pub struct StandardTilemapBundle {
     pub grid_size: TilemapGridSize,
     pub map_type: TilemapType,
@@ -168,17 +225,20 @@ pub mod prelude {
     pub use crate::helpers::transform::*;
     pub use crate::map::*;
     #[cfg(feature = "render")]
-    pub use crate::render::material::MaterialTilemap;
-    #[cfg(feature = "render")]
-    pub use crate::render::material::MaterialTilemapKey;
-    #[cfg(feature = "render")]
-    pub use crate::render::material::MaterialTilemapPlugin;
-    #[cfg(feature = "render")]
     pub use crate::render::material::StandardTilemapMaterial;
+    #[cfg(feature = "render")]
+    pub use crate::render::material::TilemapMaterial;
+    #[cfg(feature = "render")]
+    pub use crate::render::material::TilemapMaterialHandle;
+    #[cfg(feature = "render")]
+    pub use crate::render::material::TilemapMaterialKey;
+    #[cfg(feature = "render")]
+    pub use crate::render::material::TilemapMaterialPlugin;
     pub use crate::tiles::*;
     #[cfg(feature = "render")]
     pub use crate::MaterialTilemapBundle;
     #[cfg(feature = "render")]
+    pub use crate::Tilemap;
     pub use crate::TilemapBundle;
     pub use crate::TilemapPlugin;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,10 +108,11 @@ impl Default for FrustumCulling {
 #[cfg(feature = "render")]
 #[deprecated(
     since = "0.15.0",
-    note = "Use the `MaterialTilemap` component instead. Inserting it will now automatically insert the other components it requires."
+    note = "Use the `Tilemap` type alias instead. Inserting it will now automatically insert the other components it requires."
 )]
 pub type TilemapBundle = MaterialTilemapBundle<StandardTilemapMaterial>;
 
+// TODO: there may not be any point to this, since we cannot construct the type using it.
 #[cfg(feature = "render")]
 pub type Tilemap = MaterialTilemap<StandardTilemapMaterial>;
 
@@ -136,6 +137,12 @@ pub type Tilemap = MaterialTilemap<StandardTilemapMaterial>;
 )]
 /// The default tilemap, with custom Material rendering support.
 pub struct MaterialTilemap<M: TilemapMaterial>(PhantomData<M>);
+
+impl<M: TilemapMaterial> MaterialTilemap<M> {
+    pub fn new() -> Self {
+        MaterialTilemap(PhantomData)
+    }
+}
 
 #[cfg(feature = "render")]
 #[deprecated(

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -22,7 +22,7 @@ use crate::TilemapTexture;
 
 use super::{
     chunk::{ChunkId, RenderChunk2dStorage, TilemapUniformData},
-    material::{MaterialTilemap, MaterialTilemapHandle, RenderMaterialsTilemap},
+    material::{RenderMaterialsTilemap, TilemapMaterial, TilemapMaterialHandle},
     prepare::MeshUniform,
     queue::{ImageBindGroups, TilemapViewBindGroup, TransformBindGroup},
     DynamicUniformIndex,
@@ -146,13 +146,13 @@ pub type DrawTilemapMaterial<M> = (
     DrawMesh,
 );
 
-pub struct SetMaterialBindGroup<M: MaterialTilemap, const I: usize>(PhantomData<M>);
-impl<M: MaterialTilemap, const I: usize> RenderCommand<Transparent2d>
+pub struct SetMaterialBindGroup<M: TilemapMaterial, const I: usize>(PhantomData<M>);
+impl<M: TilemapMaterial, const I: usize> RenderCommand<Transparent2d>
     for SetMaterialBindGroup<M, I>
 {
     type Param = (
         SRes<RenderMaterialsTilemap<M>>,
-        SQuery<&'static MaterialTilemapHandle<M>>,
+        SQuery<&'static TilemapMaterialHandle<M>>,
     );
     type ViewQuery = ();
     type ItemQuery = Read<TilemapId>;

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -203,7 +203,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
         let Some((chunk_id, tilemap_id)) = ids else {
-            return RenderCommandResult::Failure("no chunk/tilemap ids available");
+            return RenderCommandResult::Failure("cannot obtain chunk/tilemap ids");
         };
 
         let mesh_allocator = mesh_allocator.into_inner();
@@ -214,15 +214,14 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
             chunk_id.0.z,
             tilemap_id.0.index(),
         )) {
-            let Some(mesh_instance) = mesh_instances.render_mesh_queue_data(item.main_entity())
-            else {
+            let Some(mesh_instance) = mesh_instances.get(&item.main_entity()) else {
                 return RenderCommandResult::Skip;
             };
             let Some(render_mesh) = meshes.into_inner().get(mesh_instance.mesh_asset_id) else {
                 return RenderCommandResult::Skip;
             };
             let Some(vertex_buffer_slice) =
-                mesh_allocator.mesh_vertex_slice(mesh_instance.mesh_asset_id)
+                mesh_allocator.mesh_vertex_slice(&mesh_instance.mesh_asset_id)
             else {
                 return RenderCommandResult::Skip;
             };
@@ -235,7 +234,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
                     count,
                 } => {
                     let Some(index_buffer_slice) =
-                        mesh_allocator.mesh_index_slice(render_mesh.mesh_asset_id)
+                        mesh_allocator.mesh_index_slice(&mesh_instance.mesh_asset_id)
                     else {
                         return RenderCommandResult::Skip;
                     };

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -369,7 +369,7 @@ pub fn extract(
 
     for (entity, frustum) in camera_query.iter() {
         commands
-            .get_or_spawn(entity)
+            .entity(entity)
             .insert(ExtractedFrustum { frustum: *frustum });
     }
 

--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -376,7 +376,7 @@ pub fn extract(
     commands.insert_or_spawn_batch(extracted_tiles);
     commands.insert_or_spawn_batch(extracted_tilemaps);
     commands.insert_or_spawn_batch(extracted_tilemap_textures);
-    commands.insert_resource(SecondsSinceStartup(time.elapsed_seconds_f64() as f32));
+    commands.insert_resource(SecondsSinceStartup(time.elapsed_secs_f64() as f32));
 }
 
 pub fn extract_removal(

--- a/src/render/material.rs
+++ b/src/render/material.rs
@@ -1,5 +1,6 @@
 use bevy::{
     core_pipeline::core_2d::Transparent2d,
+    ecs::system::SystemParamItem,
     math::FloatOrd,
     prelude::*,
     reflect::TypePath,
@@ -16,7 +17,7 @@ use bevy::{
             ShaderRef, SpecializedRenderPipeline, SpecializedRenderPipelines,
         },
         renderer::RenderDevice,
-        texture::{FallbackImage, GpuImage},
+        texture::GpuImage,
         view::{ExtractedView, ViewUniforms, VisibleEntities},
         Extract, Render, RenderApp, RenderSet,
     },
@@ -335,23 +336,19 @@ fn prepare_materials_tilemap<M: MaterialTilemap>(
     mut extracted_assets: ResMut<ExtractedMaterialsTilemap<M>>,
     mut render_materials: ResMut<RenderMaterialsTilemap<M>>,
     render_device: Res<RenderDevice>,
-    images: Res<RenderAssets<GpuImage>>,
-    fallback_image: Res<FallbackImage>,
     pipeline: Res<MaterialTilemapPipeline<M>>,
+    mut param: SystemParamItem<<M as AsBindGroup>::Param>,
 ) {
     let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
     for (handle, material) in queued_assets {
-        match prepare_material_tilemap(
-            &material,
-            &render_device,
-            &images,
-            &fallback_image,
-            &pipeline,
-        ) {
+        match prepare_material_tilemap(&material, &render_device, &pipeline, &mut param) {
             Ok(prepared_asset) => {
                 render_materials.insert(handle, prepared_asset);
             }
             Err(AsBindGroupError::RetryNextUpdate) => {
+                prepare_next_frame.assets.push((handle, material));
+            }
+            Err(AsBindGroupError::InvalidSamplerType(_, _, _)) => {
                 prepare_next_frame.assets.push((handle, material));
             }
         }
@@ -362,17 +359,14 @@ fn prepare_materials_tilemap<M: MaterialTilemap>(
     }
 
     for (handle, material) in std::mem::take(&mut extracted_assets.extracted) {
-        match prepare_material_tilemap(
-            &material,
-            &render_device,
-            &images,
-            &fallback_image,
-            &pipeline,
-        ) {
+        match prepare_material_tilemap(&material, &render_device, &pipeline, &mut param) {
             Ok(prepared_asset) => {
                 render_materials.insert(handle, prepared_asset);
             }
             Err(AsBindGroupError::RetryNextUpdate) => {
+                prepare_next_frame.assets.push((handle, material));
+            }
+            Err(AsBindGroupError::InvalidSamplerType(_, _, _)) => {
                 prepare_next_frame.assets.push((handle, material));
             }
         }
@@ -382,16 +376,11 @@ fn prepare_materials_tilemap<M: MaterialTilemap>(
 fn prepare_material_tilemap<M: MaterialTilemap>(
     material: &M,
     render_device: &RenderDevice,
-    images: &RenderAssets<GpuImage>,
-    fallback_image: &FallbackImage,
     pipeline: &MaterialTilemapPipeline<M>,
+    param: &mut SystemParamItem<<M as AsBindGroup>::Param>,
 ) -> Result<PreparedMaterialTilemap<M>, AsBindGroupError> {
-    let prepared = material.as_bind_group(
-        &pipeline.material_tilemap_layout,
-        render_device,
-        images,
-        fallback_image,
-    )?;
+    let prepared =
+        material.as_bind_group(&pipeline.material_tilemap_layout, render_device, param)?;
     Ok(PreparedMaterialTilemap {
         bindings: prepared.bindings,
         bind_group: prepared.bind_group,

--- a/src/render/material.rs
+++ b/src/render/material.rs
@@ -4,7 +4,7 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::{
-        extract_component::ExtractComponentPlugin,
+        extract_component::{ExtractComponent, ExtractComponentPlugin},
         globals::GlobalsBuffer,
         render_asset::RenderAssets,
         render_phase::{
@@ -411,13 +411,12 @@ pub fn queue_material_tilemap_meshes<M: MaterialTilemap>(
     pipeline_cache: Res<PipelineCache>,
     view_uniforms: Res<ViewUniforms>,
     gpu_images: Res<RenderAssets<GpuImage>>,
-    msaa: Res<Msaa>,
     globals_buffer: Res<GlobalsBuffer>,
     (standard_tilemap_meshes, materials): (
         Query<(Entity, &ChunkId, &Transform, &TilemapId)>,
         Query<&MaterialTilemapHandle<M>>,
     ),
-    mut views: Query<(Entity, &ExtractedView, &VisibleEntities)>,
+    mut views: Query<(Entity, &ExtractedView, &Msaa, &VisibleEntities)>,
     render_materials: Res<RenderMaterialsTilemap<M>>,
     #[cfg(not(feature = "atlas"))] (mut texture_array_cache, render_queue): (
         ResMut<TextureArrayCache>,
@@ -438,7 +437,7 @@ pub fn queue_material_tilemap_meshes<M: MaterialTilemap>(
         return;
     }
 
-    for (view_entity, view, visible_entities) in views.iter_mut() {
+    for (view_entity, view, msaa, visible_entities) in views.iter_mut() {
         let Some(transparent_phase) = transparent_render_phases.get_mut(&view_entity) else {
             continue;
         };

--- a/src/render/material.rs
+++ b/src/render/material.rs
@@ -99,6 +99,34 @@ where
     }
 }
 
+#[derive(Component, Clone, Debug, Deref, DerefMut, Reflect, PartialEq, Eq, ExtractComponent)]
+#[reflect(Component, Default)]
+pub struct MaterialTilemapHandle<M: MaterialTilemap>(pub Handle<M>);
+
+impl<M: MaterialTilemap> Default for MaterialTilemapHandle<M> {
+    fn default() -> Self {
+        Self(Handle::default())
+    }
+}
+
+impl<M: MaterialTilemap> From<Handle<M>> for MaterialTilemapHandle<M> {
+    fn from(handle: Handle<M>) -> Self {
+        Self(handle)
+    }
+}
+
+impl<M: MaterialTilemap> From<MaterialTilemapHandle<M>> for AssetId<M> {
+    fn from(tilemap: MaterialTilemapHandle<M>) -> Self {
+        tilemap.id()
+    }
+}
+
+impl<M: MaterialTilemap> From<&MaterialTilemapHandle<M>> for AssetId<M> {
+    fn from(tilemap: &MaterialTilemapHandle<M>) -> Self {
+        tilemap.id()
+    }
+}
+
 pub struct MaterialTilemapPlugin<M: MaterialTilemap>(PhantomData<M>);
 
 impl<M: MaterialTilemap> Default for MaterialTilemapPlugin<M> {
@@ -113,7 +141,7 @@ where
 {
     fn build(&self, app: &mut App) {
         app.init_asset::<M>()
-            .add_plugins(ExtractComponentPlugin::<Handle<M>>::extract_visible());
+            .add_plugins(ExtractComponentPlugin::<MaterialTilemapHandle<M>>::extract_visible());
     }
 
     fn finish(&self, app: &mut App) {
@@ -387,7 +415,7 @@ pub fn queue_material_tilemap_meshes<M: MaterialTilemap>(
     globals_buffer: Res<GlobalsBuffer>,
     (standard_tilemap_meshes, materials): (
         Query<(Entity, &ChunkId, &Transform, &TilemapId)>,
-        Query<&Handle<M>>,
+        Query<&MaterialTilemapHandle<M>>,
     ),
     mut views: Query<(Entity, &ExtractedView, &VisibleEntities)>,
     render_materials: Res<RenderMaterialsTilemap<M>>,
@@ -496,7 +524,10 @@ pub fn bind_material_tilemap_meshes<M: MaterialTilemap>(
     gpu_images: Res<RenderAssets<GpuImage>>,
     globals_buffer: Res<GlobalsBuffer>,
     mut image_bind_groups: ResMut<ImageBindGroups>,
-    (standard_tilemap_meshes, materials): (Query<(&ChunkId, &TilemapId)>, Query<&Handle<M>>),
+    (standard_tilemap_meshes, materials): (
+        Query<(&ChunkId, &TilemapId)>,
+        Query<&MaterialTilemapHandle<M>>,
+    ),
     mut views: Query<(Entity, &VisibleEntities)>,
     render_materials: Res<RenderMaterialsTilemap<M>>,
     modified_image_ids: Res<ModifiedImageIds>,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 use crate::{
     prelude::TilemapTexture,
     render::{
-        material::{MaterialTilemapPlugin, StandardTilemapMaterial},
+        material::{StandardTilemapMaterial, TilemapMaterialPlugin},
         prepare::{MeshUniformResource, TilemapUniformResource},
     },
 };
@@ -116,7 +116,7 @@ impl Plugin for TilemapRenderingPlugin {
         app.add_systems(First, clear_removed.in_set(TilemapFirstSet));
         app.add_systems(PostUpdate, (removal_helper, removal_helper_tilemap));
 
-        app.add_plugins(MaterialTilemapPlugin::<StandardTilemapMaterial>::default());
+        app.add_plugins(TilemapMaterialPlugin::<StandardTilemapMaterial>::default());
 
         app.world_mut()
             .resource_mut::<Assets<StandardTilemapMaterial>>()


### PR DESCRIPTION
So this is what happens when you blithely decide that, since you're gonna need `bevy_ecs_tilemap` again soon, you may as well try to upgrade it for 0.15. Uh, yeah. Some of the rendering stuff is well over my head! :sweat_smile: 

This is _not_ a working update, but I'm leaving it here in case you can cherry pick some of the simpler commits to save you some time. I'll keep trying in the meantime, I'm learning quite a bit from it... but please don't feel the need to spend any significant time reviewing it.

It does include fixes for the following:
- https://github.com/bevyengine/bevy/issues/15716 `Handle<M>` wrapper
- https://github.com/bevyengine/bevy/pull/14257 `GpuMesh` -> `RenderMesh` _but_ the implementation is nowhere near done, there's quite a lot to unpack there that I don't grok yet
- https://github.com/bevyengine/bevy/pull/15962 `elapsed_seconds` -> `elapsed_secs`
- https://github.com/bevyengine/bevy/pull/15652 `get_or_spawn` deprecation
- https://github.com/bevyengine/bevy/pull/14909 `as_bind_group` args, needed charlotte's help with that one!
- a required components migration. I'm by no means completely convinced by the naming scheme, and would welcome alternatives. But in the end it seemed to make sense to:
  - rename `MaterialTilemap` to `TilemapMaterial`...
  - ...in order to create `MaterialTilemap` to replace `MaterialTilemapBundle`