### PR TITLE
Adjust text and font sizes in examples that show coordinates

### DIFF
--- a/examples/hex_neighbors.rs
+++ b/examples/hex_neighbors.rs
@@ -92,9 +92,9 @@ fn spawn_tile_labels(
 
             let label_entity = commands
                 .spawn((
-                    Text2d::new(format!("{}, {}", tile_pos.x, tile_pos.y)),
+                    Text2d::new(format!("{},{}", tile_pos.x, tile_pos.y)),
                     TextFont {
-                        font_size: 20.0,
+                        font_size: 14.0,
                         ..default()
                     },
                     TextColor(Color::BLACK),

--- a/examples/hex_neighbors_radius_chunks.rs
+++ b/examples/hex_neighbors_radius_chunks.rs
@@ -300,7 +300,7 @@ fn swap_map_type(
                                 &map_type,
                                 &map_transform,
                             );
-                            tile_label_text.0 = format!("{}, {}", hex_pos.x, hex_pos.y);
+                            tile_label_text.0 = format!("{},{}", hex_pos.x, hex_pos.y);
                         }
                     }
                 }
@@ -327,9 +327,9 @@ fn spawn_tile_labels(
 
             let label_entity = commands
                 .spawn((
-                    Text2d(format!("{}, {}", hex_pos.x, hex_pos.y)),
+                    Text2d(format!("{},{}", hex_pos.x, hex_pos.y)),
                     TextFont {
-                        font_size: 20.0,
+                        font_size: 14.0,
                         ..default()
                     },
                     TextColor(Color::BLACK),

--- a/examples/mouse_to_tile.rs
+++ b/examples/mouse_to_tile.rs
@@ -115,9 +115,9 @@ fn spawn_tile_labels(
 
             let label_entity = commands
                 .spawn((
-                    Text2d::new(format!("{}, {}", tile_pos.x, tile_pos.y)),
+                    Text2d::new(format!("{},{}", tile_pos.x, tile_pos.y)),
                     TextFont {
-                        font_size: 20.0,
+                        font_size: 14.0,
                         ..default()
                     },
                     TextColor(Color::BLACK),


### PR DESCRIPTION
Prior to #584, these coordinate labels were already slightly oversized, often overflowing their tiles.

Now that the font is monospaced, they are *very* oversized, and are z-fighting with each other and generally looking bad.