### PR TITLE
feature: migrate to required components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["assets/*", "screenshots/*"]
 default = ["render"]
 atlas = []
 render = []
-serde = ["dep:serde"]
+serde = ["dep:serde", "bevy/serialize"]
 
 [dependencies]
 bevy = { version = "0.16.0-rc.3", default-features = false, features = [

--- a/examples/accessing_tiles.rs
+++ b/examples/accessing_tiles.rs
@@ -38,11 +38,7 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         for y in 0..map_size.y {
             let tile_pos = TilePos { x, y };
             let tile_entity = commands
-                .spawn(TileBundle {
-                    position: tile_pos,
-                    tilemap_id: TilemapId(tilemap_entity),
-                    ..Default::default()
-                })
+                .spawn((Tile, tile_pos, TilemapId(tilemap_entity)))
                 .id();
             // Here we let the tile storage component know what tiles we have.
             tile_storage.set(&tile_pos, tile_entity);
@@ -78,21 +74,20 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // This is the size of each individual tiles in pixels.
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
 
     // Spawns a tilemap.
     // Once the tile storage is inserted onto the tilemap entity it can no longer be accessed.
     commands.entity(tilemap_entity).insert((
-        TilemapBundle {
-            grid_size,
-            size: map_size,
-            storage: tile_storage,
-            map_type,
-            texture: TilemapTexture::Single(texture_handle),
-            tile_size,
-            anchor: TilemapAnchor::Center,
-            ..Default::default()
-        },
+        Tilemap,
+        grid_size,
+        map_size,
+        tile_storage,
+        map_type,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
+        tile_size,
+        TilemapAnchor::Center,
         LastUpdate(0.0),
         CurrentColor(1),
     ));

--- a/examples/anchor.rs
+++ b/examples/anchor.rs
@@ -130,16 +130,17 @@ fn spawn_tilemap(mut commands: Commands, tile_handle_square: Res<TileHandleSquar
     let grid_size = GRID_SIZE_SQUARE;
     let map_type = TilemapType::Square;
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(tile_handle_square.clone()),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(tile_handle_square.clone()),
+        TilemapMaterial::standard(),
         tile_size,
         map_type,
-        anchor: TilemapAnchor::TopLeft,
-        ..Default::default()
-    });
+        TilemapAnchor::TopLeft,
+    ));
 }
 
 #[derive(Component)]

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -4,7 +4,7 @@ use bevy::{
 };
 use bevy_ecs_tilemap::TilemapPlugin;
 use bevy_ecs_tilemap::prelude::*;
-use bevy_ecs_tilemap::tiles::{AnimatedTile, TileBundle, TilePos, TileStorage, TileTextureIndex};
+use bevy_ecs_tilemap::tiles::{AnimatedTile, TilePos, TileStorage, TileTextureIndex};
 use rand::seq::IteratorRandom;
 use rand::thread_rng;
 
@@ -53,16 +53,17 @@ fn create_background(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         size,
         grid_size,
         map_type,
         tile_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
+        TilemapAnchor::Center,
+    ));
 }
 
 fn create_animated_flowers(mut commands: Commands, asset_server: Res<AssetServer>) {
@@ -90,12 +91,10 @@ fn create_animated_flowers(mut commands: Commands, asset_server: Res<AssetServer
         let tile_pos = TilePos { x, y };
         let tile_entity = commands
             .spawn((
-                TileBundle {
-                    position: tile_pos,
-                    tilemap_id: TilemapId(tilemap_entity),
-                    texture_index: TileTextureIndex(0),
-                    ..Default::default()
-                },
+                Tile,
+                tile_pos,
+                TilemapId(tilemap_entity),
+                TileTextureIndex(0),
                 // To enable animation, we must insert the `AnimatedTile` component on
                 // each tile that is to be animated.
                 AnimatedTile {
@@ -110,17 +109,18 @@ fn create_animated_flowers(mut commands: Commands, asset_server: Res<AssetServer
     }
     let map_type = TilemapType::Square;
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
-        size: map_size,
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
+        map_size,
         grid_size,
         map_type,
         tile_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
-        anchor: TilemapAnchor::Center,
-        transform: Transform::from_xyz(0.0, 0.0, 1.0),
-        ..Default::default()
-    });
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
+        TilemapAnchor::Center,
+        Transform::from_xyz(0.0, 0.0, 1.0),
+    ));
 }
 
 fn startup(mut commands: Commands) {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -35,30 +35,27 @@ fn startup(
         for y in 0..map_size.y {
             let tile_pos = TilePos { x, y };
             let tile_entity = commands
-                .spawn(TileBundle {
-                    position: tile_pos,
-                    tilemap_id: TilemapId(tilemap_entity),
-                    ..Default::default()
-                })
+                .spawn((Tile, tile_pos, TilemapId(tilemap_entity)))
                 .id();
             tile_storage.set(&tile_pos, tile_entity);
         }
     }
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
         tile_size,
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapAnchor::Center,
+    ));
 
     // Add atlas to array texture loader so it's preprocessed before we need to use it.
     // Only used when the atlas feature is off and we are using array textures.

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -25,23 +25,24 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
         tile_size,
-        anchor: TilemapAnchor::Center,
-        render_settings: TilemapRenderSettings {
+        TilemapAnchor::Center,
+        TilemapRenderSettings {
             render_chunk_size: UVec2::new(256, 256),
             ..Default::default()
         },
-        ..Default::default()
-    });
+    ));
 }
 
 fn main() {

--- a/examples/chunking.rs
+++ b/examples/chunking.rs
@@ -21,11 +21,7 @@ fn spawn_chunk(commands: &mut Commands, asset_server: &AssetServer, chunk_pos: I
         for y in 0..CHUNK_SIZE.y {
             let tile_pos = TilePos { x, y };
             let tile_entity = commands
-                .spawn(TileBundle {
-                    position: tile_pos,
-                    tilemap_id: TilemapId(tilemap_entity),
-                    ..Default::default()
-                })
+                .spawn((Tile, tile_pos, TilemapId(tilemap_entity)))
                 .id();
             commands.entity(tilemap_entity).add_child(tile_entity);
             tile_storage.set(&tile_pos, tile_entity);
@@ -38,19 +34,20 @@ fn spawn_chunk(commands: &mut Commands, asset_server: &AssetServer, chunk_pos: I
         0.0,
     ));
     let texture_handle: Handle<Image> = asset_server.load("tiles.png");
-    commands.entity(tilemap_entity).insert(TilemapBundle {
-        grid_size: TILE_SIZE.into(),
-        size: CHUNK_SIZE.into(),
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
-        tile_size: TILE_SIZE,
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
+        TilemapGridSize::from(TILE_SIZE),
+        TilemapSize::from(CHUNK_SIZE),
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
+        TILE_SIZE,
         transform,
-        render_settings: TilemapRenderSettings {
+        TilemapRenderSettings {
             render_chunk_size: RENDER_CHUNK_SIZE,
             ..Default::default()
         },
-        ..Default::default()
-    });
+    ));
 }
 
 fn startup(mut commands: Commands) {

--- a/examples/colors.rs
+++ b/examples/colors.rs
@@ -75,18 +75,19 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
         tile_size,
-        map_type: TilemapType::Square,
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapType::Square,
+        TilemapAnchor::Center,
+    ));
 }
 
 fn main() {

--- a/examples/custom_shader.rs
+++ b/examples/custom_shader.rs
@@ -24,7 +24,7 @@ fn startup(
 ) {
     commands.spawn(Camera2d);
 
-    let my_material_handle = MaterialTilemapHandle::from(materials.add(MyMaterial {
+    let my_material = TilemapMaterial(materials.add(MyMaterial {
         brightness: 0.5,
         ..default()
     }));
@@ -46,22 +46,20 @@ fn startup(
     );
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::default();
 
-    commands
-        .entity(tilemap_entity)
-        .insert(MaterialTilemapBundle {
-            grid_size,
-            map_type,
-            size: map_size,
-            storage: tile_storage,
-            texture: TilemapTexture::Single(texture_handle.clone()),
-            tile_size,
-            anchor: TilemapAnchor::Center,
-            material: my_material_handle.clone(),
-            ..Default::default()
-        });
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
+        grid_size,
+        map_type,
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle.clone()),
+        tile_size,
+        TilemapAnchor::Center,
+        my_material.clone(),
+    ));
 
     // Layer 2
     let mut tile_storage = TileStorage::empty(map_size);
@@ -75,20 +73,18 @@ fn startup(
         &mut tile_storage,
     );
 
-    commands
-        .entity(tilemap_entity)
-        .insert(MaterialTilemapBundle {
-            grid_size,
-            map_type,
-            size: map_size,
-            storage: tile_storage,
-            texture: TilemapTexture::Single(texture_handle),
-            tile_size: TilemapTileSize { x: 16.0, y: 16.0 },
-            anchor: TilemapAnchor::Center,
-            transform: Transform::from_xyz(32.0, 32.0, 1.0),
-            material: my_material_handle,
-            ..Default::default()
-        });
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
+        grid_size,
+        map_type,
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapTileSize { x: 16.0, y: 16.0 },
+        TilemapAnchor::Center,
+        Transform::from_xyz(32.0, 32.0, 1.0),
+        my_material,
+    ));
 }
 
 fn main() {

--- a/examples/frustum_cull_test.rs
+++ b/examples/frustum_cull_test.rs
@@ -61,18 +61,19 @@ fn spawn_scene(mut commands: Commands, texture_handles: Res<TextureHandles>) {
         &mut tile_storage,
     );
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
-        grid_size: GRID_SIZE_SQUARE,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handles.square.clone()),
-        tile_size: TILE_SIZE_SQUARE,
-        map_type: TilemapType::Square,
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
+        GRID_SIZE_SQUARE,
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handles.square.clone()),
+        TilemapMaterial::standard(),
+        TILE_SIZE_SQUARE,
+        TilemapType::Square,
         // This is the default value, but we provide it explicitly for demonstration
         // purposes.
-        frustum_culling: FrustumCulling(true),
-        ..default()
-    });
+        FrustumCulling(true),
+    ));
 }
 
 fn spawn_ui(mut commands: Commands) {

--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -18,12 +18,12 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         for y in 0..map_size.y {
             let tile_pos = TilePos { x, y };
             let tile_entity = commands
-                .spawn(TileBundle {
-                    position: tile_pos,
-                    tilemap_id: TilemapId(tilemap_entity),
-                    visible: TileVisible(i % 2 == 0 || i % 7 == 0),
-                    ..Default::default()
-                })
+                .spawn((
+                    Tile,
+                    tile_pos,
+                    TilemapId(tilemap_entity),
+                    TileVisible(i % 2 == 0 || i % 7 == 0),
+                ))
                 .id();
             tile_storage.set(&tile_pos, tile_entity);
             i += 1;
@@ -31,20 +31,19 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     }
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::Square;
 
     commands.entity(tilemap_entity).insert((
-        TilemapBundle {
-            grid_size,
-            map_type,
-            size: map_size,
-            storage: tile_storage,
-            texture: TilemapTexture::Single(texture_handle),
-            tile_size,
-            anchor: TilemapAnchor::Center,
-            ..Default::default()
-        },
+        Tilemap,
+        grid_size,
+        map_type,
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
+        tile_size,
+        TilemapAnchor::Center,
         LastUpdate(0.0),
     ));
 }

--- a/examples/hex_neighbors.rs
+++ b/examples/hex_neighbors.rs
@@ -63,16 +63,17 @@ fn spawn_tilemap(mut commands: Commands, tile_handle_hex_row: Res<TileHandleHexR
     let grid_size = GRID_SIZE_HEX_ROW;
     let map_type = TilemapType::Hexagon(HexCoordSystem::Row);
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(tile_handle_hex_row.clone()),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(tile_handle_hex_row.clone()),
+        TilemapMaterial::standard(),
         tile_size,
         map_type,
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapAnchor::Center,
+    ));
 }
 
 #[derive(Component)]

--- a/examples/hex_neighbors_radius_chunks.rs
+++ b/examples/hex_neighbors_radius_chunks.rs
@@ -238,18 +238,17 @@ fn spawn_chunks(mut commands: Commands, tile_handle_hex_row: Res<TileHandleHexRo
 
             commands
                 .entity(tilemap_entity)
-                .insert(TilemapBundle {
+                .insert((
+                    Tilemap,
                     grid_size,
-                    size: map_size,
-                    storage: tile_storage,
-                    texture: TilemapTexture::Single(tile_handle_hex_row.clone()),
+                    map_size,
+                    tile_storage,
+                    TilemapTexture::Single(tile_handle_hex_row.clone()),
+                    TilemapMaterial::standard(),
                     tile_size,
                     map_type,
-                    transform: Transform::from_translation(chunk_in_world_position(
-                        *chunk_pos, map_type,
-                    )),
-                    ..Default::default()
-                })
+                    Transform::from_translation(chunk_in_world_position(*chunk_pos, map_type)),
+                ))
                 .insert(chunk_pos);
         }
     }

--- a/examples/hexagon_column.rs
+++ b/examples/hexagon_column.rs
@@ -74,16 +74,17 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let grid_size = TilemapGridSize { x: 17.0, y: 15.0 };
     let map_type = TilemapType::Hexagon(HexCoordSystem::Column);
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
         tile_size,
         map_type,
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapAnchor::Center,
+    ));
 }
 
 fn swap_mesh_type(mut query: Query<&mut TilemapType>, keyboard_input: Res<ButtonInput<KeyCode>>) {

--- a/examples/hexagon_generation.rs
+++ b/examples/hexagon_generation.rs
@@ -67,16 +67,17 @@ fn spawn_tilemap(mut commands: Commands, tile_handle_hex_row: Res<TileHandleHexR
     let grid_size = GRID_SIZE_HEX_ROW;
     let map_type = TilemapType::Hexagon(hex_coord_system);
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(tile_handle_hex_row.clone()),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(tile_handle_hex_row.clone()),
+        TilemapMaterial::standard(),
         tile_size,
         map_type,
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapAnchor::Center,
+    ));
 }
 
 #[derive(Component)]

--- a/examples/hexagon_row.rs
+++ b/examples/hexagon_row.rs
@@ -73,16 +73,17 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let grid_size = TilemapGridSize { x: 15.0, y: 17.0 };
     let map_type = TilemapType::Hexagon(HexCoordSystem::Row);
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
         tile_size,
         map_type,
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapAnchor::Center,
+    ));
 }
 
 fn swap_mesh_type(mut query: Query<&mut TilemapType>, keyboard_input: Res<ButtonInput<KeyCode>>) {

--- a/examples/iso_diamond.rs
+++ b/examples/iso_diamond.rs
@@ -71,19 +71,20 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     let tile_size = TilemapTileSize { x: 64.0, y: 32.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::Isometric(IsoCoordSystem::Diamond);
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
         tile_size,
         map_type,
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapAnchor::Center,
+    ));
 }
 
 fn main() {

--- a/examples/iso_staggered.rs
+++ b/examples/iso_staggered.rs
@@ -73,19 +73,20 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     let tile_size = TilemapTileSize { x: 64.0, y: 32.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::Isometric(IsoCoordSystem::Staggered);
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
         tile_size,
         map_type,
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapAnchor::Center,
+    ));
 }
 
 fn main() {

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -22,19 +22,20 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle.clone()),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle.clone()),
+        TilemapMaterial::standard(),
         tile_size,
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapAnchor::Center,
+    ));
 
     // Layer 2
     let mut tile_storage = TileStorage::empty(map_size);
@@ -48,17 +49,18 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         &mut tile_storage,
     );
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
-        tile_size: TilemapTileSize { x: 16.0, y: 16.0 },
-        anchor: TilemapAnchor::Center,
-        transform: Transform::from_xyz(32.0, 32.0, 1.0),
-        ..Default::default()
-    });
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
+        TilemapTileSize { x: 16.0, y: 16.0 },
+        TilemapAnchor::Center,
+        Transform::from_xyz(32.0, 32.0, 1.0),
+    ));
 }
 
 fn main() {

--- a/examples/mouse_to_tile.rs
+++ b/examples/mouse_to_tile.rs
@@ -85,16 +85,17 @@ fn spawn_tilemap(mut commands: Commands, tile_handle_square: Res<TileHandleSquar
     let grid_size = GRID_SIZE_SQUARE;
     let map_type = TilemapType::Square;
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(tile_handle_square.clone()),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(tile_handle_square.clone()),
+        TilemapMaterial::standard(),
         tile_size,
         map_type,
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapAnchor::Center,
+    ));
 }
 
 #[derive(Component)]

--- a/examples/move_tile.rs
+++ b/examples/move_tile.rs
@@ -18,28 +18,25 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     let tile_pos = TilePos { x: 0, y: 0 };
     let tile_entity = commands
-        .spawn(TileBundle {
-            position: tile_pos,
-            tilemap_id: TilemapId(tilemap_entity),
-            ..Default::default()
-        })
+        .spawn((Tile, tile_pos, TilemapId(tilemap_entity)))
         .id();
     tile_storage.set(&tile_pos, tile_entity);
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
         tile_size,
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapAnchor::Center,
+    ));
 }
 
 fn swap_pos(keyboard_input: Res<ButtonInput<KeyCode>>, mut query: Query<&mut TilePos>) {

--- a/examples/random_map.rs
+++ b/examples/random_map.rs
@@ -21,11 +21,9 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
             let tile_pos = TilePos { x, y };
             let tile_entity = commands
                 .spawn((
-                    TileBundle {
-                        position: tile_pos,
-                        tilemap_id: TilemapId(tilemap_entity),
-                        ..Default::default()
-                    },
+                    Tile,
+                    tile_pos,
+                    TilemapId(tilemap_entity),
                     LastUpdate::default(),
                 ))
                 .id();
@@ -34,19 +32,20 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     }
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
         tile_size,
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapAnchor::Center,
+    ));
 }
 
 #[derive(Default, Component)]

--- a/examples/remove_tiles.rs
+++ b/examples/remove_tiles.rs
@@ -17,31 +17,26 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         for y in 0..32u32 {
             let tile_pos = TilePos { x, y };
             let tile_entity = commands
-                .spawn(TileBundle {
-                    position: tile_pos,
-                    tilemap_id: TilemapId(tilemap_entity),
-                    ..Default::default()
-                })
+                .spawn((Tile, tile_pos, TilemapId(tilemap_entity)))
                 .id();
             tile_storage.set(&tile_pos, tile_entity);
         }
     }
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::default();
 
     commands.entity(tilemap_entity).insert((
-        TilemapBundle {
-            grid_size,
-            map_type,
-            size: map_size,
-            storage: tile_storage,
-            texture: TilemapTexture::Single(texture_handle),
-            tile_size,
-            anchor: TilemapAnchor::Center,
-            ..Default::default()
-        },
+        Tilemap,
+        grid_size,
+        map_type,
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
+        tile_size,
+        TilemapAnchor::Center,
         LastUpdate::default(),
     ));
 }

--- a/examples/spacing.rs
+++ b/examples/spacing.rs
@@ -22,20 +22,21 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::default();
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle.clone()),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle.clone()),
+        TilemapMaterial::standard(),
         tile_size,
-        spacing: TilemapSpacing { x: 8.0, y: 8.0 },
-        anchor: TilemapAnchor::Center,
-        ..Default::default()
-    });
+        TilemapSpacing { x: 8.0, y: 8.0 },
+        TilemapAnchor::Center,
+    ));
 
     // Layer 2
     let mut tile_storage = TileStorage::empty(map_size);
@@ -49,17 +50,18 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         &mut tile_storage,
     );
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
-        tile_size: TilemapTileSize { x: 16.0, y: 16.0 },
-        anchor: TilemapAnchor::Center,
-        transform: Transform::from_xyz(32.0, 32.0, 1.0),
-        ..Default::default()
-    });
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
+        TilemapTileSize { x: 16.0, y: 16.0 },
+        TilemapAnchor::Center,
+        Transform::from_xyz(32.0, 32.0, 1.0),
+    ));
 }
 
 fn main() {

--- a/examples/spawn_despawn_tilemap.rs
+++ b/examples/spawn_despawn_tilemap.rs
@@ -38,39 +38,40 @@ fn spawn_map(
         for y in 0..map_size.y {
             let tile_pos = TilePos { x, y };
             let tile_entity = commands
-                .spawn(TileBundle {
-                    position: tile_pos,
-                    tilemap_id: TilemapId(tilemap_entity),
-                    color: TileColor(
+                .spawn((
+                    Tile,
+                    tile_pos,
+                    TilemapId(tilemap_entity),
+                    TileColor(
                         Hsla::hsl(0., 0.9, 0.8)
                             .rotate_hue(num_maps as f32 * 19.)
                             .into(),
                     ),
-                    texture_index: TileTextureIndex(5),
-                    ..default()
-                })
+                    TileTextureIndex(5),
+                ))
                 .id();
             tile_storage.set(&tile_pos, tile_entity);
         }
     }
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::default();
 
     let offset = Vec3::splat(num_maps as f32 * tile_size.x / 2.);
 
-    commands.entity(tilemap_entity).insert(TilemapBundle {
+    commands.entity(tilemap_entity).insert((
+        Tilemap,
         grid_size,
         map_type,
-        size: map_size,
-        storage: tile_storage,
-        texture: TilemapTexture::Single(texture_handle),
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
         tile_size,
-        anchor: TilemapAnchor::Center,
-        transform: Transform::from_translation(offset),
-        ..default()
-    });
+        TilemapAnchor::Center,
+        Transform::from_translation(offset),
+    ));
 }
 
 fn despawn_map(mut commands: Commands, mut maps: Query<(Entity, &mut TileStorage, &Transform)>) {

--- a/examples/texture_container.rs
+++ b/examples/texture_container.rs
@@ -61,31 +61,25 @@ mod no_atlas {
                 .choose_weighted(&mut rng, |choice| choice.1)
                 .unwrap()
                 .0;
-            let tile_entity = commands
-                .spawn(TileBundle {
-                    position,
-                    tilemap_id,
-                    texture_index: texture,
-                    ..Default::default()
-                })
-                .id();
+            let tile_entity = commands.spawn((Tile, position, tilemap_id, texture)).id();
             tile_storage.set(&position, tile_entity);
         }
 
         let tile_size = TILE_SIZE;
-        let grid_size = TILE_SIZE.into();
+        let grid_size = TilemapGridSize::from(TILE_SIZE);
         let map_type = TilemapType::Hexagon(COORD_SYS);
 
-        commands.entity(tilemap_entity).insert(TilemapBundle {
+        commands.entity(tilemap_entity).insert((
+            Tilemap,
             grid_size,
             map_type,
             tile_size,
-            size: map_size,
-            storage: tile_storage,
-            texture: texture_vec,
-            anchor: TilemapAnchor::Center,
-            ..Default::default()
-        });
+            map_size,
+            tile_storage,
+            texture_vec,
+            TilemapMaterial::standard(),
+            TilemapAnchor::Center,
+        ));
     }
 
     pub fn main() {

--- a/examples/texture_vec.rs
+++ b/examples/texture_vec.rs
@@ -55,31 +55,25 @@ mod no_atlas {
                 .choose_weighted(&mut rng, |choice| choice.1)
                 .unwrap()
                 .0;
-            let tile_entity = commands
-                .spawn(TileBundle {
-                    position,
-                    tilemap_id,
-                    texture_index: texture,
-                    ..Default::default()
-                })
-                .id();
+            let tile_entity = commands.spawn((Tile, position, tilemap_id, texture)).id();
             tile_storage.set(&position, tile_entity);
         }
 
         let tile_size = TILE_SIZE;
-        let grid_size = TILE_SIZE.into();
+        let grid_size = TilemapGridSize::from(TILE_SIZE);
         let map_type = TilemapType::Hexagon(COORD_SYS);
 
-        commands.entity(tilemap_entity).insert(TilemapBundle {
+        commands.entity(tilemap_entity).insert((
+            Tilemap,
             grid_size,
             map_type,
             tile_size,
-            size: map_size,
-            storage: tile_storage,
-            texture: texture_vec,
-            anchor: TilemapAnchor::Center,
-            ..Default::default()
-        });
+            map_size,
+            tile_storage,
+            texture_vec,
+            TilemapMaterial::standard(),
+            TilemapAnchor::Center,
+        ));
     }
 
     pub fn main() {

--- a/examples/visibility.rs
+++ b/examples/visibility.rs
@@ -17,31 +17,26 @@ fn startup(mut commands: Commands, asset_server: Res<AssetServer>) {
         for y in 0..32u32 {
             let tile_pos = TilePos { x, y };
             let tile_entity = commands
-                .spawn(TileBundle {
-                    position: tile_pos,
-                    tilemap_id: TilemapId(tilemap_entity),
-                    ..Default::default()
-                })
+                .spawn((Tile, tile_pos, TilemapId(tilemap_entity)))
                 .id();
             tile_storage.set(&tile_pos, tile_entity);
         }
     }
 
     let tile_size = TilemapTileSize { x: 16.0, y: 16.0 };
-    let grid_size = tile_size.into();
+    let grid_size = TilemapGridSize::from(tile_size);
     let map_type = TilemapType::default();
 
     commands.entity(tilemap_entity).insert((
-        TilemapBundle {
-            grid_size,
-            map_type,
-            size: map_size,
-            storage: tile_storage,
-            texture: TilemapTexture::Single(texture_handle),
-            tile_size,
-            anchor: TilemapAnchor::Center,
-            ..Default::default()
-        },
+        Tilemap,
+        grid_size,
+        map_type,
+        map_size,
+        tile_storage,
+        TilemapTexture::Single(texture_handle),
+        TilemapMaterial::standard(),
+        tile_size,
+        TilemapAnchor::Center,
         LastUpdate::default(),
     ));
 }

--- a/src/helpers/filling.rs
+++ b/src/helpers/filling.rs
@@ -2,7 +2,7 @@ use crate::helpers::hex_grid::axial::AxialPos;
 use crate::helpers::hex_grid::neighbors::{HEX_DIRECTIONS, HexDirection};
 use crate::map::TilemapId;
 use crate::prelude::HexCoordSystem;
-use crate::tiles::{TileBundle, TileColor, TilePos, TileTextureIndex};
+use crate::tiles::{Tile, TileColor, TilePos, TileTextureIndex};
 use crate::{TileStorage, TilemapSize};
 
 use bevy::prelude::{Color, Commands};
@@ -20,12 +20,7 @@ pub fn fill_tilemap(
             for y in 0..size.y {
                 let tile_pos = TilePos { x, y };
                 let tile_entity = parent
-                    .spawn(TileBundle {
-                        position: tile_pos,
-                        tilemap_id,
-                        texture_index,
-                        ..Default::default()
-                    })
+                    .spawn((Tile, tile_pos, tilemap_id, texture_index))
                     .id();
                 tile_storage.set(&tile_pos, tile_entity);
             }
@@ -54,12 +49,7 @@ pub fn fill_tilemap_rect(
                 };
 
                 let tile_entity = parent
-                    .spawn(TileBundle {
-                        position: tile_pos,
-                        tilemap_id,
-                        texture_index,
-                        ..Default::default()
-                    })
+                    .spawn((Tile, tile_pos, tilemap_id, texture_index))
                     .id();
                 tile_storage.set(&tile_pos, tile_entity);
             }
@@ -89,13 +79,7 @@ pub fn fill_tilemap_rect_color(
                 };
 
                 let tile_entity = parent
-                    .spawn(TileBundle {
-                        position: tile_pos,
-                        tilemap_id,
-                        texture_index,
-                        color: TileColor(color),
-                        ..Default::default()
-                    })
+                    .spawn((Tile, tile_pos, tilemap_id, texture_index, TileColor(color)))
                     .id();
                 tile_storage.set(&tile_pos, tile_entity);
             }
@@ -167,12 +151,7 @@ pub fn fill_tilemap_hexagon(
     commands.entity(tilemap_id.0).with_children(|parent| {
         for tile_pos in tile_positions {
             let tile_entity = parent
-                .spawn(TileBundle {
-                    position: tile_pos,
-                    tilemap_id,
-                    texture_index,
-                    ..Default::default()
-                })
+                .spawn((Tile, tile_pos, tilemap_id, texture_index))
                 .id();
             tile_storage.checked_set(&tile_pos, tile_entity)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use bevy::{
 };
 
 #[cfg(feature = "render")]
-use render::material::MaterialTilemapHandle;
+use render::material::TilemapMaterial;
 
 use anchor::TilemapAnchor;
 use map::{
@@ -112,11 +112,22 @@ impl Default for FrustumCulling {
 }
 
 #[cfg(feature = "render")]
+#[expect(deprecated)]
+#[deprecated(
+    since = "0.16.0",
+    note = "Use the `Tilemap` and `TilemapMaterial::standard()` components instead. 
+        Inserting `Tilemap` will now also insert all necessary components automatically."
+)]
 pub type TilemapBundle = MaterialTilemapBundle<StandardTilemapMaterial>;
 
 #[cfg(feature = "render")]
 /// The default tilemap bundle. All of the components within are required.
 #[derive(Bundle, Debug, Default, Clone)]
+#[deprecated(
+    since = "0.16.0",
+    note = "Use the `Tilemap` and `TilemapMaterial<M>` components instead. 
+        Inserting `Tilemap` will now also insert all necessary components automatically."
+)]
 pub struct MaterialTilemapBundle<M: MaterialTilemap> {
     pub grid_size: TilemapGridSize,
     pub map_type: TilemapType,
@@ -136,14 +147,37 @@ pub struct MaterialTilemapBundle<M: MaterialTilemap> {
     pub view_visibility: ViewVisibility,
     /// User indication of whether tilemap should be frustum culled.
     pub frustum_culling: FrustumCulling,
-    pub material: MaterialTilemapHandle<M>,
+    pub material: TilemapMaterial<M>,
     pub sync: SyncToRenderWorld,
     pub anchor: TilemapAnchor,
 }
 
+#[derive(Component, Debug, Default, Clone)]
+#[require(
+    TilemapGridSize,
+    TilemapType,
+    TilemapSize,
+    TilemapSpacing,
+    TileStorage,
+    TilemapTexture,
+    TilemapTileSize,
+    Transform,
+    TilemapRenderSettings,
+    TilemapAnchor,
+    Visibility,
+    FrustumCulling,
+    SyncToRenderWorld
+)]
+pub struct Tilemap;
+
 #[cfg(not(feature = "render"))]
 /// The default tilemap bundle. All of the components within are required.
 #[derive(Bundle, Debug, Default, Clone)]
+#[deprecated(
+    since = "0.16.0",
+    note = "Use the `Tilemap` component instead. 
+        Inserting `Tilemap` will now also insert all necessary components automatically."
+)]
 pub struct StandardTilemapBundle {
     pub grid_size: TilemapGridSize,
     pub map_type: TilemapType,
@@ -169,8 +203,11 @@ pub struct StandardTilemapBundle {
 /// A module which exports commonly used dependencies.
 pub mod prelude {
     #[cfg(feature = "render")]
+    #[expect(deprecated)]
     pub use crate::MaterialTilemapBundle;
+    pub use crate::Tilemap;
     #[cfg(feature = "render")]
+    #[expect(deprecated)]
     pub use crate::TilemapBundle;
     pub use crate::TilemapPlugin;
     pub use crate::anchor::TilemapAnchor;
@@ -184,13 +221,13 @@ pub mod prelude {
     #[cfg(feature = "render")]
     pub use crate::render::material::MaterialTilemap;
     #[cfg(feature = "render")]
-    pub use crate::render::material::MaterialTilemapHandle;
-    #[cfg(feature = "render")]
     pub use crate::render::material::MaterialTilemapKey;
     #[cfg(feature = "render")]
     pub use crate::render::material::MaterialTilemapPlugin;
     #[cfg(feature = "render")]
     pub use crate::render::material::StandardTilemapMaterial;
+    #[cfg(feature = "render")]
+    pub use crate::render::material::TilemapMaterial;
     pub use crate::tiles::*;
 }
 

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -21,7 +21,7 @@ use crate::map::TilemapId;
 use super::{
     DynamicUniformIndex,
     chunk::{ChunkId, RenderChunk2dStorage, TilemapUniformData},
-    material::{MaterialTilemap, MaterialTilemapHandle, RenderMaterialsTilemap},
+    material::{MaterialTilemap, TilemapMaterial, RenderMaterialsTilemap},
     prepare::MeshUniform,
     queue::{ImageBindGroups, TilemapViewBindGroup, TransformBindGroup},
 };
@@ -150,7 +150,7 @@ impl<M: MaterialTilemap, const I: usize> RenderCommand<Transparent2d>
 {
     type Param = (
         SRes<RenderMaterialsTilemap<M>>,
-        SQuery<&'static MaterialTilemapHandle<M>>,
+        SQuery<&'static TilemapMaterial<M>>,
     );
     type ViewQuery = ();
     type ItemQuery = Read<TilemapId>;

--- a/src/tiles/mod.rs
+++ b/src/tiles/mod.rs
@@ -108,9 +108,27 @@ pub struct TileFlip {
     pub d: bool, // anti
 }
 
+#[derive(Component, Default, Clone, Copy, Debug)]
+#[require(
+    TilePos,
+    TileTextureIndex,
+    TilemapId,
+    TileVisible,
+    TileFlip,
+    TileColor,
+    TilePosOld,
+    SyncToRenderWorld
+)]
+pub struct Tile;
+
 /// This an optional tile bundle with default components.
 #[derive(Bundle, Default, Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[deprecated(
+    since = "0.16.0",
+    note = "Use the `Tile` component instead.
+        Inserting `Tile` will now also insert all necessary components automatically."
+)]
 pub struct TileBundle {
     pub position: TilePos,
     pub texture_index: TileTextureIndex,


### PR DESCRIPTION
Closes https://github.com/StarArawn/bevy_ecs_tilemap/issues/597

# Objective

- Required components replaces bundles, but the crate still contains many user-facing bundles.


## Solution

- Deprecate the following bundles:
  - `TileBundle`
  - `MaterialTilemapBundle`
  - `TilemapBundle`
  - `StandardTilemapBundle`

- Migrate all examples to required components.
- Deprecate `MaterialTilemapHandle` in favor of `TilemapMaterial`. This is a pure name change done for two reasons:
  - To conform to the idiomatic pattern used [upstream](https://github.com/bevyengine/bevy/blob/71a9142deda547a872da3cc2b6a6300bad6e86a6/examples/3d/3d_shapes.rs#L83-L93):
    ```rust
    commands.spawn((
        Mesh3d(shape),
        MeshMaterial3d(material),
    ));
    ```
  - The material component is now something that is explicitly inserted by the user. So, we need to make sure that it's not cumbersome to remember and type.

## Testing

I've ran all the tests on Linux (Wayland) and they all look fine to me. But I'm not 100% familiar with all the quirks and edge-cases of this crate. So if I've overlooked any potential regressions, do let me know 🙂

## Migration Guide

The bundles are now all deprecated. With the new version, you should instead compose together `Tile`, `Tilemap` and `TilemapMaterial` to achieve your desired behavior.

Before:

```rust
commands.spawn(TileBundle::default());

commands.spawn(MaterialTilemapBundle {
    material,
    ..default(),
});

commands.spawn(TilemapBundle::default());

commands.spawn(StandardTilemapBundle::default());
```

After:

```rust
commands.spawn(Tile);

commands.spawn((Tilemap, TilemapMaterial(material)));

commands.spawn((Tilemap, TilemapMaterial::standard()));

commands.spawn(Tilemap);
```