### PR TITLE
Update to bevy 0.16rc4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ render = []
 serde = ["dep:serde"]
 
 [dependencies]
-bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+bevy = { version = "0.16.0-rc.4", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",
     "bevy_sprite",
-    "bevy_log",
+    "tracing",
 ] }
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
@@ -34,7 +34,7 @@ tiled = { version = "0.14.0", default-features = false }
 thiserror = { version = "2.0" }
 
 [dev-dependencies.bevy]
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 default-features = false
 features = [
     "bevy_core_pipeline",
@@ -55,7 +55,7 @@ features = [
 ]
 
 [target.'cfg(unix)'.dev-dependencies.bevy]
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 default-features = false
 features = [
     "bevy_core_pipeline",


### PR DESCRIPTION
The only breaking change I found is the renaming of the `bevy_log` feature to `tracing` from this [pr](https://github.com/bevyengine/bevy/commit/c5365509bfbef5f19345b84b51258ff37944fe72).

I did test the majority of examples on linux