### PR TITLE
fix(#611): enable Bevy `serialize` feature when building with `serde` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["assets/*", "screenshots/*"]
 default = ["render"]
 atlas = []
 render = []
-serde = ["dep:serde"]
+serde = ["dep:serde", "bevy/serialize"]
 
 [dependencies]
 bevy = { version = "0.16.0", default-features = false, features = [


### PR DESCRIPTION
Fix #611

Just enable the `serialize` feature from Bevy when we build bevy_ecs_tilemap with the `serde` feature.