### PR TITLE
fix renderer removing packed tile data on swapped tiles

### DIFF
--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -74,8 +74,7 @@ pub(crate) fn prepare(
     mut mesh_vertex_buffer_layouts: ResMut<MeshVertexBufferLayouts>,
 ) {
     // We use this to keep track of which tile positions have been set this frame.
-    let mut recently_updated: HashSet<TilePos> =
-        HashSet::with_capacity(extracted_tiles.iter().len());
+    let mut recently_updated: HashSet<TilePos> = HashSet::new();
 
     for tile in extracted_tiles.iter() {
         // First if the tile position has changed remove the tile from the old location,

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -7,8 +7,10 @@ use crate::map::{
 };
 use crate::prelude::TilemapRenderSettings;
 use crate::render::extract::ExtractedFrustum;
+use crate::tiles::TilePos;
 use crate::{FrustumCulling, prelude::TilemapGridSize, render::RenderChunkSize};
 use bevy::log::trace;
+use bevy::platform::collections::HashSet;
 use bevy::prelude::{InheritedVisibility, Resource, Transform, With};
 use bevy::render::mesh::MeshVertexBufferLayouts;
 use bevy::render::sync_world::TemporaryRenderEntity;
@@ -71,9 +73,15 @@ pub(crate) fn prepare(
     render_queue: Res<RenderQueue>,
     mut mesh_vertex_buffer_layouts: ResMut<MeshVertexBufferLayouts>,
 ) {
+    // We use this to keep track of which tile positions have been set this frame.
+    let mut recently_updated: HashSet<TilePos> =
+        HashSet::with_capacity(extracted_tiles.iter().len());
+
     for tile in extracted_tiles.iter() {
-        // First if the tile position has changed remove the tile from the old location.
-        if tile.position != tile.old_position.0 {
+        // First if the tile position has changed remove the tile from the old location,
+        // but not if the old location has already been replaced with another tile.
+        if tile.position != tile.old_position.0 && !recently_updated.contains(&tile.old_position.0)
+        {
             chunk_storage.remove_tile_with_entity(tile.entity);
         }
 
@@ -133,6 +141,7 @@ pub(crate) fn prepare(
                 ..tile.tile
             }),
         );
+        recently_updated.insert(tile.position);
     }
 
     // Copies transform changes from tilemap to chunks.


### PR DESCRIPTION
Fixes #559.

## Problem
The render checks to see if the tile's old position and new position do not match and it greedily remove's it from the chunk at that old position. If a tile earlier in the iteration was placed at that tile's old location it will be removed and the tile data is lost.

## Solution
We introduce a set and use it to check if the tile's old position in the chunk was updated by an entity in a previous iteration.