### PR TITLE
bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ecs_tilemap"
 description = "A tilemap rendering plugin for bevy which is more ECS friendly by having an entity per tile."
-version = "0.17.0"
+version = "0.18.0-rc.1"
 authors = ["John Mitchell"]
 homepage = "https://github.com/StarArawn/bevy_ecs_tilemap"
 repository = "https://github.com/StarArawn/bevy_ecs_tilemap"
@@ -16,7 +16,7 @@ render = []
 serde = ["dep:serde", "bevy/serialize"]
 
 [dependencies]
-bevy = { version = "0.17.0", default-features = false, features = [
+bevy = { version = "0.18.0-rc.1", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",
@@ -34,7 +34,7 @@ tiled = { version = "0.14.0", default-features = false }
 thiserror = { version = "2.0" }
 
 [dev-dependencies.bevy]
-version = "0.17.0"
+version = "0.18.0-rc.1"
 default-features = false
 features = [
     "bevy_core_pipeline",
@@ -52,10 +52,11 @@ features = [
     "default_font",
     "webgl2",
     "bevy_gizmos",
+    "gamepad",
 ]
 
 [target.'cfg(unix)'.dev-dependencies.bevy]
-version = "0.17.0"
+version = "0.18.0-rc.1"
 default-features = false
 features = [
     "bevy_core_pipeline",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ecs_tilemap"
 description = "A tilemap rendering plugin for bevy which is more ECS friendly by having an entity per tile."
-version = "0.18.0"
+version = "0.18.1"
 authors = ["John Mitchell"]
 homepage = "https://github.com/StarArawn/bevy_ecs_tilemap"
 repository = "https://github.com/StarArawn/bevy_ecs_tilemap"
@@ -22,6 +22,9 @@ bevy = { version = "0.18.0", default-features = false, features = [
     "bevy_asset",
     "bevy_sprite_render",
     "bevy_log",
+    # we don't actually use morph, but it it a bevy_mesh feature
+    # that removes fields if it is not included.
+    "morph"
 ] }
 log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ecs_tilemap"
 description = "A tilemap rendering plugin for bevy which is more ECS friendly by having an entity per tile."
-version = "0.18.0-rc.1"
+version = "0.18.0"
 authors = ["John Mitchell"]
 homepage = "https://github.com/StarArawn/bevy_ecs_tilemap"
 repository = "https://github.com/StarArawn/bevy_ecs_tilemap"
@@ -16,7 +16,7 @@ render = []
 serde = ["dep:serde", "bevy/serialize"]
 
 [dependencies]
-bevy = { version = "0.18.0-rc.1", default-features = false, features = [
+bevy = { version = "0.18.0", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",
@@ -34,7 +34,7 @@ tiled = { version = "0.14.0", default-features = false }
 thiserror = { version = "2.0" }
 
 [dev-dependencies.bevy]
-version = "0.18.0-rc.1"
+version = "0.18.0"
 default-features = false
 features = [
     "bevy_core_pipeline",
@@ -56,7 +56,7 @@ features = [
 ]
 
 [target.'cfg(unix)'.dev-dependencies.bevy]
-version = "0.18.0-rc.1"
+version = "0.18.0"
 default-features = false
 features = [
     "bevy_core_pipeline",

--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ cargo run --target wasm32-unknown-unknown --example animation
 
 #### WebGPU
 
-WebGPU is not yet well [supported](https://caniuse.com/webgpu) by many browsers.
-
 ```
 cargo run --example animation --target=wasm32-unknown-unknown --features=bevy/webgpu
 ```
@@ -108,6 +106,7 @@ cargo run --example animation --target=wasm32-unknown-unknown --features=bevy/we
 | bevy   | bevy_ecs_tilemap |
 | ------ | ---------------- |
 | `main` | `bevy-track`     |
+| 0.18   | 0.18             |
 | 0.17   | 0.17             |
 | 0.16   | 0.16             |
 | 0.15   | 0.15             |

--- a/examples/helpers/ldtk.rs
+++ b/examples/helpers/ldtk.rs
@@ -1,8 +1,8 @@
 use bevy_ecs_tilemap::{
+    TilemapBundle,
     anchor::TilemapAnchor,
     map::{TilemapId, TilemapSize, TilemapTexture, TilemapTileSize},
     tiles::{TileBundle, TilePos, TileStorage, TileTextureIndex},
-    TilemapBundle,
 };
 use std::collections::HashMap;
 use thiserror::Error;

--- a/examples/helpers/ldtk.rs
+++ b/examples/helpers/ldtk.rs
@@ -1,8 +1,8 @@
 use bevy_ecs_tilemap::{
-    TilemapBundle,
     anchor::TilemapAnchor,
     map::{TilemapId, TilemapSize, TilemapTexture, TilemapTileSize},
     tiles::{TileBundle, TilePos, TileStorage, TileTextureIndex},
+    TilemapBundle,
 };
 use std::collections::HashMap;
 use thiserror::Error;
@@ -52,6 +52,7 @@ pub struct LdtkMapBundle {
     pub global_transform: GlobalTransform,
 }
 
+#[derive(TypePath)]
 pub struct LdtkLoader;
 
 #[allow(dead_code)]
@@ -87,7 +88,7 @@ impl AssetLoader for LdtkLoader {
                 tileset.rel_path.as_ref().map(|rel_path| {
                     (
                         tileset.uid,
-                        load_context.path().parent().unwrap().join(rel_path).into(),
+                        load_context.path().resolve_embed(rel_path).unwrap(),
                     )
                 })
             })

--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use bevy::log::{info, warn};
 use bevy::{
-    asset::{io::Reader, AssetLoader, AssetPath},
+    asset::{AssetLoader, AssetPath, io::Reader},
     platform::collections::HashMap,
     prelude::{
         Added, Asset, AssetApp, AssetEvent, AssetId, Assets, Bundle, Commands, Component, Entity,

--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use bevy::log::{info, warn};
 use bevy::{
-    asset::{AssetLoader, AssetPath, io::Reader},
+    asset::{AssetLoader, io::Reader},
     platform::collections::HashMap,
     prelude::{
         Added, Asset, AssetApp, AssetEvent, AssetId, Assets, Bundle, Commands, Component, Entity,
@@ -157,7 +157,7 @@ impl AssetLoader for TiledLoader {
                                 // assets/ directory structure then the tmx_dir will be empty, which is fine.
                                 let asset_path = load_context
                                     .path()
-                                    .resolve(&img.source.to_string_lossy())
+                                    .resolve_embed(&img.source.to_string_lossy())
                                     .expect("The asset load context was empty.");
                                 info!(
                                     "Loading tile image from {asset_path:?} as image ({tileset_index}, {tile_id})"
@@ -175,12 +175,12 @@ impl AssetLoader for TiledLoader {
                 Some(img) => {
                     // The load context path is the TMX file itself. If the file is at the root of the
                     // assets/ directory structure then the tmx_dir will be empty, which is fine.
-                    let tmx_dir = load_context
+                    let asset_path = load_context
                         .path()
-                        .parent()
+                        .resolve_embed(&img.source.to_string_lossy())
                         .expect("The asset load context was empty.");
-                    let tile_path = tmx_dir.path().join(&img.source);
-                    let asset_path = AssetPath::from(tile_path);
+
+                    info!(?asset_path);
                     let texture: Handle<Image> = load_context.load(asset_path.clone());
 
                     TilemapTexture::Single(texture.clone())

--- a/examples/helpers/tiled.rs
+++ b/examples/helpers/tiled.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use bevy::log::{info, warn};
 use bevy::{
-    asset::{AssetLoader, AssetPath, io::Reader},
+    asset::{io::Reader, AssetLoader, AssetPath},
     platform::collections::HashMap,
     prelude::{
         Added, Asset, AssetApp, AssetEvent, AssetId, Assets, Bundle, Commands, Component, Entity,
@@ -99,6 +99,7 @@ impl tiled::ResourceReader for BytesResourceReader {
 }
 
 #[allow(dead_code)]
+#[derive(TypePath)]
 pub struct TiledLoader;
 
 #[allow(dead_code)]
@@ -128,7 +129,7 @@ impl AssetLoader for TiledLoader {
             BytesResourceReader::new(&bytes),
         );
         let map = loader
-            .load_tmx_map(load_context.path())
+            .load_tmx_map(load_context.path().path())
             .map_err(|e| std::io::Error::other(format!("Could not load TMX map: {e}")))?;
 
         let mut tilemap_textures = HashMap::default();
@@ -154,12 +155,10 @@ impl AssetLoader for TiledLoader {
                             if let Some(img) = &tile.image {
                                 // The load context path is the TMX file itself. If the file is at the root of the
                                 // assets/ directory structure then the tmx_dir will be empty, which is fine.
-                                let tmx_dir = load_context
+                                let asset_path = load_context
                                     .path()
-                                    .parent()
+                                    .resolve(&img.source.to_string_lossy())
                                     .expect("The asset load context was empty.");
-                                let tile_path = tmx_dir.join(&img.source);
-                                let asset_path = AssetPath::from(tile_path);
                                 info!(
                                     "Loading tile image from {asset_path:?} as image ({tileset_index}, {tile_id})"
                                 );
@@ -180,7 +179,7 @@ impl AssetLoader for TiledLoader {
                         .path()
                         .parent()
                         .expect("The asset load context was empty.");
-                    let tile_path = tmx_dir.join(&img.source);
+                    let tile_path = tmx_dir.path().join(&img.source);
                     let asset_path = AssetPath::from(tile_path);
                     let texture: Handle<Image> = load_context.load(asset_path.clone());
 
@@ -198,7 +197,7 @@ impl AssetLoader for TiledLoader {
             tile_image_offsets,
         };
 
-        info!("Loaded map: {}", load_context.path().display());
+        info!("Loaded map: {}", load_context.path());
         Ok(asset_map)
     }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,6 +1,6 @@
 use bevy::{
     asset::Assets,
-    camera::visibility::{add_visibility_class, VisibilityClass},
+    camera::visibility::{VisibilityClass, add_visibility_class},
     ecs::{
         entity::{EntityMapper, MapEntities},
         reflect::ReflectMapEntities,

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,6 +1,6 @@
 use bevy::{
     asset::Assets,
-    camera::visibility::{VisibilityClass, add_visibility_class},
+    camera::visibility::{add_visibility_class, VisibilityClass},
     ecs::{
         entity::{EntityMapper, MapEntities},
         reflect::ReflectMapEntities,
@@ -459,10 +459,11 @@ pub enum IsoCoordSystem {
 }
 
 /// The type of tile to be rendered, currently we support: Square, Hex, and Isometric.
-#[derive(Component, Reflect, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Component, Reflect, Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[reflect(Component)]
 pub enum TilemapType {
     /// A tilemap with rectangular tiles.
+    #[default]
     Square,
     /// Used to specify rendering of tilemaps on hexagons.
     ///
@@ -472,12 +473,6 @@ pub enum TilemapType {
     ///
     /// The `IsoCoordSystem` determines the coordinate system.
     Isometric(IsoCoordSystem),
-}
-
-impl Default for TilemapType {
-    fn default() -> Self {
-        Self::Square
-    }
 }
 
 #[cfg(test)]

--- a/src/render/chunk.rs
+++ b/src/render/chunk.rs
@@ -24,9 +24,9 @@ use bevy::{mesh::VertexAttributeValues, render::render_resource::Buffer};
 use crate::prelude::helpers::transform::{chunk_aabb, chunk_index_to_world_space};
 use crate::render::extract::ExtractedFrustum;
 use crate::{
+    FrustumCulling, TilemapGridSize, TilemapTileSize,
     map::{TilemapSize, TilemapTexture, TilemapType},
     tiles::TilePos,
-    FrustumCulling, TilemapGridSize, TilemapTileSize,
 };
 
 use super::RenderChunkSize;

--- a/src/render/chunk.rs
+++ b/src/render/chunk.rs
@@ -24,9 +24,9 @@ use bevy::{mesh::VertexAttributeValues, render::render_resource::Buffer};
 use crate::prelude::helpers::transform::{chunk_aabb, chunk_index_to_world_space};
 use crate::render::extract::ExtractedFrustum;
 use crate::{
-    FrustumCulling, TilemapGridSize, TilemapTileSize,
     map::{TilemapSize, TilemapTexture, TilemapType},
     tiles::TilePos,
+    FrustumCulling, TilemapGridSize, TilemapTileSize,
 };
 
 use super::RenderChunkSize;
@@ -171,7 +171,7 @@ impl RenderChunk2dStorage {
     }
 
     pub fn remove_map(&mut self, entity: Entity) {
-        self.chunks.remove(&entity.index());
+        self.chunks.remove(&entity.index_u32());
     }
 }
 
@@ -460,7 +460,6 @@ impl RenderChunk2d {
             self.render_mesh = Some(RenderMesh {
                 vertex_count: self.mesh.count_vertices() as u32,
                 buffer_info,
-                morph_targets: None,
                 layout: mesh_vertex_buffer_layout,
                 key_bits: BaseMeshPipelineKey::from_primitive_topology(
                     PrimitiveTopology::TriangleList,

--- a/src/render/chunk.rs
+++ b/src/render/chunk.rs
@@ -464,6 +464,7 @@ impl RenderChunk2d {
                 key_bits: BaseMeshPipelineKey::from_primitive_topology(
                     PrimitiveTopology::TriangleList,
                 ),
+                morph_targets: None,
             });
             self.vertex_buffer = Some(vertex_buffer);
             self.index_buffer = Some(index_buffer);

--- a/src/render/chunk.rs
+++ b/src/render/chunk.rs
@@ -464,7 +464,7 @@ impl RenderChunk2d {
                 key_bits: BaseMeshPipelineKey::from_primitive_topology(
                     PrimitiveTopology::TriangleList,
                 ),
-                morph_targets: None
+                morph_targets: None,
             });
             self.vertex_buffer = Some(vertex_buffer);
             self.index_buffer = Some(index_buffer);

--- a/src/render/chunk.rs
+++ b/src/render/chunk.rs
@@ -464,7 +464,6 @@ impl RenderChunk2d {
                 key_bits: BaseMeshPipelineKey::from_primitive_topology(
                     PrimitiveTopology::TriangleList,
                 ),
-                morph_targets: None,
             });
             self.vertex_buffer = Some(vertex_buffer);
             self.index_buffer = Some(index_buffer);

--- a/src/render/chunk.rs
+++ b/src/render/chunk.rs
@@ -464,6 +464,7 @@ impl RenderChunk2d {
                 key_bits: BaseMeshPipelineKey::from_primitive_topology(
                     PrimitiveTopology::TriangleList,
                 ),
+                morph_targets: None
             });
             self.vertex_buffer = Some(vertex_buffer);
             self.index_buffer = Some(index_buffer);

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -3,8 +3,8 @@ use std::marker::PhantomData;
 use bevy::{
     core_pipeline::core_2d::Transparent2d,
     ecs::system::{
-        lifetimeless::{Read, SQuery, SRes},
         SystemParamItem,
+        lifetimeless::{Read, SQuery, SRes},
     },
     math::UVec4,
     render::{
@@ -15,15 +15,15 @@ use bevy::{
     },
 };
 
-use crate::map::TilemapId;
 use crate::TilemapTexture;
+use crate::map::TilemapId;
 
 use super::{
+    DynamicUniformIndex,
     chunk::{ChunkId, RenderChunk2dStorage, TilemapUniformData},
     material::{MaterialTilemap, MaterialTilemapHandle, RenderMaterialsTilemap},
     prepare::MeshUniform,
     queue::{ImageBindGroups, TilemapViewBindGroup, TransformBindGroup},
-    DynamicUniformIndex,
 };
 
 pub struct SetMeshViewBindGroup<const I: usize>;

--- a/src/render/draw.rs
+++ b/src/render/draw.rs
@@ -3,8 +3,8 @@ use std::marker::PhantomData;
 use bevy::{
     core_pipeline::core_2d::Transparent2d,
     ecs::system::{
-        SystemParamItem,
         lifetimeless::{Read, SQuery, SRes},
+        SystemParamItem,
     },
     math::UVec4,
     render::{
@@ -15,15 +15,15 @@ use bevy::{
     },
 };
 
-use crate::TilemapTexture;
 use crate::map::TilemapId;
+use crate::TilemapTexture;
 
 use super::{
-    DynamicUniformIndex,
     chunk::{ChunkId, RenderChunk2dStorage, TilemapUniformData},
     material::{MaterialTilemap, MaterialTilemapHandle, RenderMaterialsTilemap},
     prepare::MeshUniform,
     queue::{ImageBindGroups, TilemapViewBindGroup, TransformBindGroup},
+    DynamicUniformIndex,
 };
 
 pub struct SetMeshViewBindGroup<const I: usize>;
@@ -199,7 +199,7 @@ impl RenderCommand<Transparent2d> for DrawMesh {
             chunk_id.0.x,
             chunk_id.0.y,
             chunk_id.0.z,
-            tilemap_id.0.index(),
+            tilemap_id.0.index_u32(),
         )) && let (Some(render_mesh), Some(vertex_buffer), Some(index_buffer)) = (
             &chunk.render_mesh,
             &chunk.vertex_buffer,
@@ -215,7 +215,7 @@ impl RenderCommand<Transparent2d> for DrawMesh {
                     index_format,
                     count,
                 } => {
-                    pass.set_index_buffer(index_buffer.slice(..), 0, *index_format);
+                    pass.set_index_buffer(index_buffer.slice(..), *index_format);
                     pass.draw_indexed(0..*count, 0, 0..1);
                 }
                 RenderMeshBufferInfo::NonIndexed => {

--- a/src/render/material.rs
+++ b/src/render/material.rs
@@ -10,6 +10,7 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::{
+        Extract, Render, RenderApp, RenderSystems,
         extract_component::{ExtractComponent, ExtractComponentPlugin},
         globals::GlobalsBuffer,
         render_asset::RenderAssets,
@@ -24,19 +25,18 @@ use bevy::{
         renderer::RenderDevice,
         texture::GpuImage,
         view::{ExtractedView, RenderVisibleEntities, ViewUniforms},
-        Extract, Render, RenderApp, RenderSystems,
     },
 };
 use bevy::{log::error, shader::ShaderRef};
 use std::{hash::Hash, marker::PhantomData};
 
 use super::{
+    ModifiedImageIds,
     chunk::{ChunkId, RenderChunk2dStorage},
     draw::DrawTilemapMaterial,
     pipeline::{TilemapPipeline, TilemapPipelineKey},
     prepare,
     queue::{ImageBindGroups, TilemapViewBindGroup},
-    ModifiedImageIds,
 };
 
 #[cfg(not(feature = "atlas"))]

--- a/src/render/material.rs
+++ b/src/render/material.rs
@@ -10,7 +10,6 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::{
-        Extract, Render, RenderApp, RenderSystems,
         extract_component::{ExtractComponent, ExtractComponentPlugin},
         globals::GlobalsBuffer,
         render_asset::RenderAssets,
@@ -18,25 +17,26 @@ use bevy::{
             AddRenderCommand, DrawFunctions, PhaseItemExtraIndex, ViewSortedRenderPhases,
         },
         render_resource::{
-            AsBindGroup, AsBindGroupError, BindGroup, BindGroupEntry, BindGroupLayout,
+            AsBindGroup, AsBindGroupError, BindGroup, BindGroupEntry, BindGroupLayoutDescriptor,
             BindingResource, OwnedBindingResource, PipelineCache, RenderPipelineDescriptor,
             SpecializedRenderPipeline, SpecializedRenderPipelines,
         },
         renderer::RenderDevice,
         texture::GpuImage,
         view::{ExtractedView, RenderVisibleEntities, ViewUniforms},
+        Extract, Render, RenderApp, RenderSystems,
     },
 };
 use bevy::{log::error, shader::ShaderRef};
 use std::{hash::Hash, marker::PhantomData};
 
 use super::{
-    ModifiedImageIds,
     chunk::{ChunkId, RenderChunk2dStorage},
     draw::DrawTilemapMaterial,
     pipeline::{TilemapPipeline, TilemapPipelineKey},
     prepare,
     queue::{ImageBindGroups, TilemapViewBindGroup},
+    ModifiedImageIds,
 };
 
 #[cfg(not(feature = "atlas"))]
@@ -200,7 +200,7 @@ impl<M: MaterialTilemap> Default for ExtractedMaterialsTilemap<M> {
 #[derive(Resource)]
 pub struct MaterialTilemapPipeline<M: MaterialTilemap> {
     pub tilemap_pipeline: TilemapPipeline,
-    pub material_tilemap_layout: BindGroupLayout,
+    pub material_tilemap_layout: BindGroupLayoutDescriptor,
     pub vertex_shader: Option<Handle<Shader>>,
     pub fragment_shader: Option<Handle<Shader>>,
     marker: PhantomData<M>,
@@ -249,7 +249,7 @@ impl<M: MaterialTilemap> FromWorld for MaterialTilemapPipeline<M> {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.resource::<AssetServer>();
         let render_device = world.resource::<RenderDevice>();
-        let material_tilemap_layout = M::bind_group_layout(render_device);
+        let material_tilemap_layout = M::bind_group_layout_descriptor(render_device);
 
         MaterialTilemapPipeline {
             tilemap_pipeline: world.resource::<TilemapPipeline>().clone(),
@@ -338,10 +338,17 @@ fn prepare_materials_tilemap<M: MaterialTilemap>(
     render_device: Res<RenderDevice>,
     pipeline: Res<MaterialTilemapPipeline<M>>,
     mut param: StaticSystemParam<M::Param>,
+    pipeline_cache: Res<PipelineCache>,
 ) {
     let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
     for (handle, material) in queued_assets {
-        match prepare_material_tilemap(&material, &render_device, &pipeline, &mut param) {
+        match prepare_material_tilemap(
+            &material,
+            &render_device,
+            &pipeline,
+            &pipeline_cache,
+            &mut param,
+        ) {
             Ok(prepared_asset) => {
                 render_materials.insert(handle, prepared_asset);
             }
@@ -364,7 +371,13 @@ fn prepare_materials_tilemap<M: MaterialTilemap>(
     }
 
     for (handle, material) in std::mem::take(&mut extracted_assets.extracted) {
-        match prepare_material_tilemap(&material, &render_device, &pipeline, &mut param) {
+        match prepare_material_tilemap(
+            &material,
+            &render_device,
+            &pipeline,
+            &pipeline_cache,
+            &mut param,
+        ) {
             Ok(prepared_asset) => {
                 render_materials.insert(handle, prepared_asset);
             }
@@ -387,10 +400,15 @@ fn prepare_material_tilemap<M: MaterialTilemap>(
     material: &M,
     render_device: &RenderDevice,
     pipeline: &MaterialTilemapPipeline<M>,
+    pipeline_cache: &PipelineCache,
     param: &mut SystemParamItem<M::Param>,
 ) -> Result<PreparedMaterialTilemap<M>, AsBindGroupError> {
-    let prepared =
-        material.as_bind_group(&pipeline.material_tilemap_layout, render_device, param)?;
+    let prepared = material.as_bind_group(
+        &pipeline.material_tilemap_layout,
+        render_device,
+        pipeline_cache,
+        param,
+    )?;
     let bind_group_data = material.bind_group_data();
     Ok(PreparedMaterialTilemap {
         bindings: prepared.bindings.0,
@@ -468,7 +486,7 @@ pub fn queue_material_tilemap_meshes<M: MaterialTilemap>(
                 chunk_id.0.x,
                 chunk_id.0.y,
                 chunk_id.0.z,
-                tilemap_id.0.index(),
+                tilemap_id.0.index_u32(),
             )) {
                 #[cfg(not(feature = "atlas"))]
                 if !texture_array_cache.contains(&chunk.texture) {
@@ -523,6 +541,7 @@ pub fn bind_material_tilemap_meshes<M: MaterialTilemap>(
     mut commands: Commands,
     chunk_storage: Res<RenderChunk2dStorage>,
     render_device: Res<RenderDevice>,
+    pipeline_cache: Res<PipelineCache>,
     tilemap_pipeline: Res<TilemapPipeline>,
     view_uniforms: Res<ViewUniforms>,
     gpu_images: Res<RenderAssets<GpuImage>>,
@@ -556,7 +575,7 @@ pub fn bind_material_tilemap_meshes<M: MaterialTilemap>(
         for (entity, visible_entities) in views.iter_mut() {
             let view_bind_group = render_device.create_bind_group(
                 Some("tilemap_view_bind_group"),
-                &tilemap_pipeline.view_layout,
+                &pipeline_cache.get_bind_group_layout(&tilemap_pipeline.view_layout),
                 &[
                     BindGroupEntry {
                         binding: 0,
@@ -593,7 +612,7 @@ pub fn bind_material_tilemap_meshes<M: MaterialTilemap>(
                     chunk_id.0.x,
                     chunk_id.0.y,
                     chunk_id.0.z,
-                    tilemap_id.0.index(),
+                    tilemap_id.0.index_u32(),
                 )) {
                     #[cfg(not(feature = "atlas"))]
                     if !texture_array_cache.contains(&chunk.texture) {
@@ -612,7 +631,8 @@ pub fn bind_material_tilemap_meshes<M: MaterialTilemap>(
                         let gpu_image = gpu_images.get(chunk.texture.image_handle()).unwrap();
                         render_device.create_bind_group(
                             Some("sprite_material_bind_group"),
-                            &tilemap_pipeline.material_layout,
+                            &pipeline_cache
+                                .get_bind_group_layout(&tilemap_pipeline.material_layout),
                             &[
                                 BindGroupEntry {
                                     binding: 0,

--- a/src/render/pipeline.rs
+++ b/src/render/pipeline.rs
@@ -7,15 +7,14 @@ use bevy::{
     render::{
         globals::GlobalsUniform,
         render_resource::{
-            BindGroupLayout, BindGroupLayoutEntry, BindingType, BlendComponent, BlendFactor,
-            BlendOperation, BlendState, BufferBindingType, ColorTargetState, ColorWrites,
-            CompareFunction, DepthBiasState, DepthStencilState, Face, FragmentState, FrontFace,
-            MultisampleState, PolygonMode, PrimitiveState, PrimitiveTopology,
+            BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, BlendComponent,
+            BlendFactor, BlendOperation, BlendState, BufferBindingType, ColorTargetState,
+            ColorWrites, CompareFunction, DepthBiasState, DepthStencilState, Face, FragmentState,
+            FrontFace, MultisampleState, PolygonMode, PrimitiveState, PrimitiveTopology,
             RenderPipelineDescriptor, SamplerBindingType, ShaderStages, ShaderType,
             SpecializedRenderPipeline, StencilFaceState, StencilState, TextureFormat,
             TextureSampleType, TextureViewDimension, VertexFormat, VertexState, VertexStepMode,
         },
-        renderer::RenderDevice,
         view::{ViewTarget, ViewUniform},
     },
 };
@@ -31,16 +30,14 @@ pub const TILEMAP_SHADER_FRAGMENT: Handle<Shader> =
 
 #[derive(Clone, Resource)]
 pub struct TilemapPipeline {
-    pub view_layout: BindGroupLayout,
-    pub material_layout: BindGroupLayout,
-    pub mesh_layout: BindGroupLayout,
+    pub view_layout: BindGroupLayoutDescriptor,
+    pub material_layout: BindGroupLayoutDescriptor,
+    pub mesh_layout: BindGroupLayoutDescriptor,
 }
 
 impl FromWorld for TilemapPipeline {
-    fn from_world(world: &mut World) -> Self {
-        let render_device = world.get_resource::<RenderDevice>().unwrap();
-
-        let view_layout = render_device.create_bind_group_layout(
+    fn from_world(_world: &mut World) -> Self {
+        let view_layout = BindGroupLayoutDescriptor::new(
             "tilemap_view_layout",
             &[
                 // View
@@ -67,7 +64,7 @@ impl FromWorld for TilemapPipeline {
             ],
         );
 
-        let mesh_layout = render_device.create_bind_group_layout(
+        let mesh_layout = BindGroupLayoutDescriptor::new(
             "tilemap_mesh_layout",
             &[
                 BindGroupLayoutEntry {
@@ -96,7 +93,7 @@ impl FromWorld for TilemapPipeline {
         );
 
         #[cfg(not(feature = "atlas"))]
-        let material_layout = render_device.create_bind_group_layout(
+        let material_layout = BindGroupLayoutDescriptor::new(
             "tilemap_material_layout",
             &[
                 BindGroupLayoutEntry {
@@ -119,7 +116,7 @@ impl FromWorld for TilemapPipeline {
         );
 
         #[cfg(feature = "atlas")]
-        let material_layout = render_device.create_bind_group_layout(
+        let material_layout = BindGroupLayoutDescriptor::new(
             "tilemap_material_layout",
             &[
                 BindGroupLayoutEntry {

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -7,7 +7,7 @@ use crate::map::{
 };
 use crate::prelude::TilemapRenderSettings;
 use crate::render::extract::ExtractedFrustum;
-use crate::{prelude::TilemapGridSize, render::RenderChunkSize, FrustumCulling};
+use crate::{FrustumCulling, prelude::TilemapGridSize, render::RenderChunkSize};
 use bevy::prelude::{InheritedVisibility, Resource, Transform, With};
 use bevy::render::sync_world::TemporaryRenderEntity;
 use bevy::{log::trace, mesh::MeshVertexBufferLayouts};
@@ -22,9 +22,9 @@ use bevy::{
 
 use super::extract::ChangedInMainWorld;
 use super::{
+    DynamicUniformIndex,
     chunk::{ChunkId, PackedTileData, RenderChunk2dStorage, TilemapUniformData},
     extract::{ExtractedTile, ExtractedTilemapTexture},
-    DynamicUniformIndex,
 };
 use super::{RemovedMapEntity, RemovedTileEntity};
 

--- a/src/render/prepare.rs
+++ b/src/render/prepare.rs
@@ -7,7 +7,7 @@ use crate::map::{
 };
 use crate::prelude::TilemapRenderSettings;
 use crate::render::extract::ExtractedFrustum;
-use crate::{FrustumCulling, prelude::TilemapGridSize, render::RenderChunkSize};
+use crate::{prelude::TilemapGridSize, render::RenderChunkSize, FrustumCulling};
 use bevy::prelude::{InheritedVisibility, Resource, Transform, With};
 use bevy::render::sync_world::TemporaryRenderEntity;
 use bevy::{log::trace, mesh::MeshVertexBufferLayouts};
@@ -22,9 +22,9 @@ use bevy::{
 
 use super::extract::ChangedInMainWorld;
 use super::{
-    DynamicUniformIndex,
     chunk::{ChunkId, PackedTileData, RenderChunk2dStorage, TilemapUniformData},
     extract::{ExtractedTile, ExtractedTilemapTexture},
+    DynamicUniformIndex,
 };
 use super::{RemovedMapEntity, RemovedTileEntity};
 
@@ -98,7 +98,7 @@ pub(crate) fn prepare(
             chunk_index.x,
             chunk_index.y,
             transform.translation().z as u32,
-            tile.tilemap_id.0.index(),
+            tile.tilemap_id.0.index_u32(),
         );
 
         let in_chunk_tile_index = chunk_size.map_tile_to_chunk_tile(&tile.position, &chunk_index);
@@ -151,7 +151,7 @@ pub(crate) fn prepare(
         anchor,
     ) in extracted_tilemaps.iter()
     {
-        let chunks = chunk_storage.get_chunk_storage(&UVec4::new(0, 0, 0, entity.index()));
+        let chunks = chunk_storage.get_chunk_storage(&UVec4::new(0, 0, 0, entity.index_u32()));
         for chunk in chunks.values_mut() {
             chunk.texture = texture.clone();
             chunk.map_size = *map_size;
@@ -179,7 +179,7 @@ pub(crate) fn prepare(
     for tilemap in extracted_tilemap_textures.iter() {
         let texture_size: Vec2 = tilemap.texture_size.into();
         let chunks =
-            chunk_storage.get_chunk_storage(&UVec4::new(0, 0, 0, tilemap.tilemap_id.0.index()));
+            chunk_storage.get_chunk_storage(&UVec4::new(0, 0, 0, tilemap.tilemap_id.0.index_u32()));
         for chunk in chunks.values_mut() {
             chunk.texture_size = texture_size;
         }

--- a/src/render/queue.rs
+++ b/src/render/queue.rs
@@ -2,7 +2,7 @@ use bevy::{
     platform::collections::HashMap,
     prelude::*,
     render::{
-        render_resource::{BindGroup, BindGroupEntry},
+        render_resource::{BindGroup, BindGroupEntry, PipelineCache},
         renderer::RenderDevice,
     },
 };
@@ -24,6 +24,7 @@ pub fn queue_transform_bind_group(
     render_device: Res<RenderDevice>,
     transform_uniforms: Res<MeshUniformResource>,
     tilemap_uniforms: Res<TilemapUniformResource>,
+    pipeline_cache: Res<PipelineCache>,
 ) {
     if let (Some(binding1), Some(binding2)) =
         (transform_uniforms.0.binding(), tilemap_uniforms.0.binding())
@@ -31,7 +32,7 @@ pub fn queue_transform_bind_group(
         commands.insert_resource(TransformBindGroup {
             value: render_device.create_bind_group(
                 Some("transform_bind_group"),
-                &tilemap_pipeline.mesh_layout,
+                &pipeline_cache.get_bind_group_layout(&tilemap_pipeline.mesh_layout),
                 &[
                     BindGroupEntry {
                         binding: 0,

--- a/src/render/texture_array_cache.rs
+++ b/src/render/texture_array_cache.rs
@@ -218,6 +218,8 @@ impl TextureArrayCache {
                             depth_or_array_layers: 1,
                         },
                         mip_level_count,
+                        texture_view_format: Some(*format),
+                        had_data: false,
                     };
 
                     self.textures.insert(texture.clone(), gpu_image);


### PR DESCRIPTION
Update to bevy 0.18 for the release candidate.

Biggest change is the bindgrouplayoutdescriptor change: https://github.com/bevyengine/bevy/pull/21205

Other changes include entity index -> index_u32, and a couple small field changes.