### PR TITLE
log when tilemap has missing components

### DIFF
--- a/src/render/extract.rs
+++ b/src/render/extract.rs
@@ -282,7 +282,13 @@ pub fn extract(
             color: color.0.to_linear().to_f32_array(),
         };
 
-        let data = tilemap_query.get(tilemap_id.0).unwrap();
+        let Ok(data) = tilemap_query.get(tilemap_id.0) else {
+            error!(
+                "Failed to extract tilemap {}. Entity doesn't have the required components",
+                tilemap_id.0
+            );
+            continue;
+        };
 
         extracted_tilemaps.insert(
             data.0.id(),


### PR DESCRIPTION
Avoids an unwrap when the tilemap doesn't have all the expected components. I encountered this when I called `fill_tilemap_rect` on a tilemap that I'd forgotten to insert all of the components on to.

Before
```
thread 'Compute Task Pool (2)' (66899) panicked at /home/choc/code/bevy_ecs_tilemap/src/render/extract.rs:285:52:
called `Result::unwrap()` on an `Err` value: QueryDoesNotMatch(46v0, ArchetypeId(22))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_ecs_tilemap::render::extract::extract`!
```

After
```
2026-06-12T05:15:17.198799Z ERROR bevy_ecs_tilemap::render::extract: Failed to extract tilemap 43v0. Entity doesn't have the expected components
```
