### PR TITLE
Stop adding TilemapRenderingPlugin or texture preload when RenderApp is not available.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,15 +64,18 @@ pub struct TilemapPlugin;
 impl Plugin for TilemapPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         #[cfg(feature = "render")]
-        app.add_plugins(render::TilemapRenderingPlugin);
+        if app.get_sub_app(RenderApp).is_some() {
+            app.add_plugins(render::TilemapRenderingPlugin);
+        }
 
         app.add_systems(First, update_changed_tile_positions.in_set(TilemapFirstSet));
 
         #[cfg(all(not(feature = "atlas"), feature = "render"))]
         {
             app.insert_resource(array_texture_preload::ArrayTextureLoader::default());
-            let render_app = app.sub_app_mut(RenderApp);
-            render_app.add_systems(ExtractSchedule, array_texture_preload::extract);
+            if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
+                render_app.add_systems(ExtractSchedule, array_texture_preload::extract);
+            }
         }
 
         app.register_type::<FrustumCulling>()


### PR DESCRIPTION
Fixes https://github.com/StarArawn/bevy_ecs_tilemap/issues/50

I don't have deep knowledge of `bevy_ecs_tilemap`, but this humble change has served me well enough. With this change, I can run my server in headless mode without dropping `render` feature (which I still need on my client crate).